### PR TITLE
Mistake in the fat Jar path

### DIFF
--- a/gradle-verticle/README.adoc
+++ b/gradle-verticle/README.adoc
@@ -14,7 +14,7 @@ To build the "fat jar"
 
 To run the fat jar:
 
-    java -jar target/gradle-verticle-3.0.0-SNAPSHOT-fat.jar
+    java -jar build/libs/gradle-verticle-3.0.0-SNAPSHOT-fat.jar
 
 (You can take that jar and run it anywhere there is a Java 8+ JDK. It contains all the dependencies it needs so you
 don't need to install Vert.x on the target machine).


### PR DESCRIPTION
While using gradle jars are kept inside build/libs rather target(like maven)