### PR TITLE
Fixing unit test example with junit

### DIFF
--- a/unit-examples/src/test/java/io/vertx/example/unit/test/MyJUnitTest.java
+++ b/unit-examples/src/test/java/io/vertx/example/unit/test/MyJUnitTest.java
@@ -42,9 +42,11 @@ public class MyJUnitTest {
     HttpClient client = vertx.createHttpClient();
     Async async = context.async();
     client.getNow(8080, "localhost", "/", resp -> {
-      resp.bodyHandler(body -> context.assertEquals("foo", body.toString()));
-      client.close();
-      async.complete();
+      resp.bodyHandler(body -> {
+          context.assertEquals("foo", body.toString());
+          client.close();
+          async.complete();
+      });
     });
   }
 

--- a/unit-examples/src/test/java/io/vertx/example/unit/test/MyJUnitTest.java
+++ b/unit-examples/src/test/java/io/vertx/example/unit/test/MyJUnitTest.java
@@ -43,9 +43,9 @@ public class MyJUnitTest {
     Async async = context.async();
     client.getNow(8080, "localhost", "/", resp -> {
       resp.bodyHandler(body -> {
-          context.assertEquals("foo", body.toString());
-          client.close();
-          async.complete();
+        context.assertEquals("foo", body.toString());
+        client.close();
+        async.complete();
       });
     });
   }


### PR DESCRIPTION
AssertEquals was in the wrong callback. When the assert is false the async context already had finished.