### PR TITLE
fixed dependency to auth

### DIFF
--- a/metrics-examples/pom.xml
+++ b/metrics-examples/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth</artifactId>
+      <type>pom</type>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
examples do not compile, because in current setup (I have maven 3.0.5) it requires vertx-auth of type of jar but vertx-auth is a root project with type of pom.