### PR TITLE
update auth artifactId

### DIFF
--- a/web-examples/README.adoc
+++ b/web-examples/README.adoc
@@ -31,7 +31,7 @@ If you're using auth in your Vert.x-Web application you will also need the depen
 
 ----
 Group ID: io.vertx
-Artifact ID: vertx-auth
+Artifact ID: vertx-auth-common
 ----
 
 If you're using a template engine you will also need to add the engine dependency explicitly, depending on the engine


### PR DESCRIPTION
The correct dependency required to use auth with vertx-web would be vertx-auth-common.
The readme may also mention that an implementation would be required as well, although somebody implementing auth would probably figure out that pretty soon.