### PR TITLE
Improve the sharing HTTP server example

### DIFF
--- a/core-examples/README.adoc
+++ b/core-examples/README.adoc
@@ -138,6 +138,28 @@ is uploaded successfully even if the file is very large (GigaBytes).
 link:src/main/java/io/vertx/example/core/http/upload/Server.java[Java upload server example]
 link:src/main/java/io/vertx/example/core/http/upload/Client.java[Java upload client example]
 
+=== HTTP Server Sharing
+
+A server that illustrates the round robin orchestrated by vert.x when several verticles are opening HTTP servers on the same port:
+
+link:src/main/java/io/vertx/example/core/http/sharing/Server.java[Server Launcher]
+
+link:src/main/java/io/vertx/example/core/http/sharing/HttpServerVerticle.java[HTTP Server Verticle]
+
+The `Server` deploys two instances of the `HttpServerVerticle` verticle.
+
+You can run the server then open a browser and point it at link:http://localhost:8080[]. Requests will be handled by an instance after the other.
+
+The `Client` illustrates the round robin by periodically requesting the server and displays the response content.
+
+link:src/main/java/io/vertx/example/core/http/sharing/Client.java[Java simple HTTP client]
+
+You can directly launch the `HTTPServerVerticle` using the `vertx run` command. Then you can set the number of instance you want:
+
+```
+vertx run io.vertx.example.core.http.sharing.HttpServerVerticle -instances 4
+```
+
 === WebSockets echo example
 
 This example shows a Vert.x HTTP server which handles websockets connections. This example simply echoes back to the client

--- a/core-examples/src/main/groovy/io/vertx/example/core/http/sharing/client.groovy
+++ b/core-examples/src/main/groovy/io/vertx/example/core/http/sharing/client.groovy
@@ -1,9 +1,7 @@
-
-vertx.setPeriodic(100, { l ->
+vertx.setPeriodic(1000, { l ->
   vertx.createHttpClient().getNow(8080, "localhost", "/", { resp ->
     resp.bodyHandler({ body ->
       println(body.toString("ISO-8859-1"))
     })
   })
 })
-

--- a/core-examples/src/main/groovy/io/vertx/example/core/http/sharing/httpserververticle.groovy
+++ b/core-examples/src/main/groovy/io/vertx/example/core/http/sharing/httpserververticle.groovy
@@ -1,0 +1,3 @@
+vertx.createHttpServer().requestHandler({ req ->
+  req.response().putHeader("content-type", "text/html").end("<html><body><h1>Hello from ${this}</h1></body></html>")
+}).listen(8080)

--- a/core-examples/src/main/java/io/vertx/example/core/http/sharing/Client.java
+++ b/core-examples/src/main/java/io/vertx/example/core/http/sharing/Client.java
@@ -16,8 +16,7 @@ public class Client extends AbstractVerticle {
 
   @Override
   public void start() throws Exception {
-
-    vertx.setPeriodic(100, (l) -> {
+    vertx.setPeriodic(1000, (l) -> {
           vertx.createHttpClient().getNow(8080, "localhost", "/", resp -> {
             resp.bodyHandler(body -> {
               System.out.println(body.toString("ISO-8859-1"));
@@ -25,6 +24,5 @@ public class Client extends AbstractVerticle {
           });
         }
     );
-
   }
 }

--- a/core-examples/src/main/java/io/vertx/example/core/http/sharing/HttpServerVerticle.java
+++ b/core-examples/src/main/java/io/vertx/example/core/http/sharing/HttpServerVerticle.java
@@ -1,0 +1,18 @@
+package io.vertx.example.core.http.sharing;
+
+import io.vertx.core.AbstractVerticle;
+
+/**
+ * A very simple HTTP server returning it's 'id' in the response.
+ */
+public class HttpServerVerticle extends AbstractVerticle {
+  @Override
+  public void start() throws Exception {
+    vertx.createHttpServer().requestHandler(req -> {
+      req.response()
+          .putHeader("content-type", "text/html")
+          .end("<html><body><h1>Hello from " +  this + "</h1></body></html>");
+    }).listen(8080);
+  }
+}
+

--- a/core-examples/src/main/java/io/vertx/example/core/http/sharing/Server.java
+++ b/core-examples/src/main/java/io/vertx/example/core/http/sharing/Server.java
@@ -1,40 +1,23 @@
 package io.vertx.example.core.http.sharing;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
 import io.vertx.example.util.Runner;
 
 /**
  * An example illustrating the server sharing and round robin. The servers are identified using an id.
+ * The HTTP Server Verticle is instantiated twice in the deployment options.
  */
 public class Server extends AbstractVerticle {
 
-  // Convenience method so you can run it in your IDE
   public static void main(String[] args) {
     Runner.runExample(Server.class);
   }
 
   @Override
   public void start() throws Exception {
-    getVertx().deployVerticle(new HttpVerticle("server-1"));
-    getVertx().deployVerticle(new HttpVerticle("server-2"));
-  }
-
-
-  private class HttpVerticle extends AbstractVerticle {
-
-    private final String id;
-
-    private HttpVerticle(String id) {
-      this.id = id;
-    }
-
-
-    @Override
-    public void start() throws Exception {
-      vertx.createHttpServer().requestHandler(req -> {
-        req.response().putHeader("content-type", "text/html").end("<html><body><h1>Hello from " +
-            id + "</h1></body></html>");
-      }).listen(8080);
-    }
+    getVertx().deployVerticle(
+        "io.vertx.example.core.http.sharing.HttpServerVerticle",
+        new DeploymentOptions().setInstances(2));
   }
 }

--- a/core-examples/src/main/js/io/vertx/example/core/http/sharing/client.js
+++ b/core-examples/src/main/js/io/vertx/example/core/http/sharing/client.js
@@ -1,9 +1,7 @@
-
-vertx.setPeriodic(100, function (l) {
+vertx.setPeriodic(1000, function (l) {
   vertx.createHttpClient().getNow(8080, "localhost", "/", function (resp) {
     resp.bodyHandler(function (body) {
       console.log(body.toString("ISO-8859-1"));
     });
   });
 });
-

--- a/core-examples/src/main/js/io/vertx/example/core/http/sharing/httpserververticle.js
+++ b/core-examples/src/main/js/io/vertx/example/core/http/sharing/httpserververticle.js
@@ -1,0 +1,3 @@
+vertx.createHttpServer().requestHandler(function (req) {
+  req.response().putHeader("content-type", "text/html").end("<html><body><h1>Hello from " + this + "</h1></body></html>");
+}).listen(8080);

--- a/core-examples/src/main/rb/io/vertx/example/core/http/sharing/client.rb
+++ b/core-examples/src/main/rb/io/vertx/example/core/http/sharing/client.rb
@@ -1,9 +1,7 @@
-
-$vertx.set_periodic(100) { |l|
+$vertx.set_periodic(1000) { |l|
   $vertx.create_http_client().get_now(8080, "localhost", "/") { |resp|
     resp.body_handler() { |body|
       puts body.to_string("ISO-8859-1")
     }
   }
 }
-

--- a/core-examples/src/main/rb/io/vertx/example/core/http/sharing/httpserververticle.rb
+++ b/core-examples/src/main/rb/io/vertx/example/core/http/sharing/httpserververticle.rb
@@ -1,0 +1,3 @@
+$vertx.create_http_server().request_handler() { |req|
+  req.response().put_header("content-type", "text/html").end("<html><body><h1>Hello from #{$this}</h1></body></html>")
+}.listen(8080)


### PR DESCRIPTION
This commit adds a section in the REDME file with some explanation and launch instructions
It also change how was made the example to allow code generation (codetrans)
It also modifies the example to rely on the `-instances`  vert.x parameter

It should answer to points opened by https://github.com/vert-x3/vertx-examples/pull/20#issuecomment-108827319

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>