### PR TITLE
OSGi examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -134,3 +134,8 @@ The mail examples show different ways to create the mail message and send it via
 tls, ssl etc. The examples either use `localhost:25` to send a mail or use host
 `mail.example.com`. To actually run the examples you will have to change the
 mail server and the user credentials in the `MailLogin` example.
+
+==== OSGi Examples
+
+The link:osgi-examples/README.adoc[Vert.x OSGi examples] contains a few examples using Vert.x in an OSGi context.
+

--- a/osgi-examples/README.adoc
+++ b/osgi-examples/README.adoc
@@ -1,0 +1,24 @@
+= Vert.x OSGi examples
+
+Here you will find examples demonstrating Vert.x core in OSGi.
+
+Vert.x core is packaged as an OSGi bundle that can be deployed in OSGi frameworks R4.2+. However, it requires Jackson and Netty to be deployed. Check the Vert.x core manual for further details.
+
+== Vertx Activator
+
+A `Bundle Activator` exposing the Vert.x instance and the event bus as OSGi service.
+
+link:src/main/java/io/vertx/example/osgi/VertxActivator.java[Bundle Activator]
+
+== Using Vert.x as a service
+
+An http://ipojo.org[Apache Felix iPOJO] component consuming the `vertx` service to create a HTTP server.
+
+link:src/main/java/io/vertx/example/osgi/VertxHttpServer.java[Vertx Http Server]
+
+== Exposing Verticles as services
+
+Verticles can be exposed as a service and consumed using a white-board pattern. Here is an example
+
+* link:src/main/java/io/vertx/example/osgi/VertxVerticleHost.java[The whiteboard pattern host]
+* link:src/main/java/io/vertx/example/osgi/VertxHttpClientVerticle.java[A verticle exposed as an OSGi service]

--- a/osgi-examples/pom.xml
+++ b/osgi-examples/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-examples</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>osgi-examples</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.0.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+      <version>1.12.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>5.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- BND Maven Plugin Configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Private-Package>io.vertx.example.osgi</Private-Package>
+            <Bundle-Activator>io.vertx.example.osgi.VertxActivator</Bundle-Activator>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-ipojo-plugin</artifactId>
+        <version>1.12.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>ipojo-bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/osgi-examples/src/main/java/io/vertx/example/osgi/VertxActivator.java
+++ b/osgi-examples/src/main/java/io/vertx/example/osgi/VertxActivator.java
@@ -1,0 +1,42 @@
+package io.vertx.example.osgi;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import java.util.logging.Logger;
+
+/**
+ * A bundle activator registering the Vert.x instance and the event bus as OSGi service.
+ */
+public class VertxActivator implements BundleActivator {
+
+  private final static Logger LOGGER = Logger.getLogger("VertxPublisher");
+  private ServiceRegistration<Vertx> vertxRegistration;
+  private ServiceRegistration<EventBus> ebRegistration;
+
+  @Override
+  public void start(BundleContext context) throws Exception {
+    LOGGER.info("Creating Vert.x instance");
+    Vertx vertx = Vertx.vertx();
+    vertxRegistration = context.registerService(Vertx.class, vertx, null);
+    LOGGER.info("Vert.x service registered");
+    vertxRegistration = context.registerService(Vertx.class, vertx, null);
+    LOGGER.info("Vert.x Event Bus service registered");
+    ebRegistration = context.registerService(EventBus.class, vertx.eventBus(), null);
+  }
+
+  @Override
+  public void stop(BundleContext context) throws Exception {
+    if (vertxRegistration != null) {
+      vertxRegistration.unregister();
+      vertxRegistration = null;
+    }
+    if (ebRegistration != null) {
+      ebRegistration.unregister();
+      ebRegistration = null;
+    }
+  }
+}

--- a/osgi-examples/src/main/java/io/vertx/example/osgi/VertxHttpClientVerticle.java
+++ b/osgi-examples/src/main/java/io/vertx/example/osgi/VertxHttpClientVerticle.java
@@ -1,0 +1,27 @@
+package io.vertx.example.osgi;
+
+import io.vertx.core.AbstractVerticle;
+import org.apache.felix.ipojo.annotations.Component;
+import org.apache.felix.ipojo.annotations.Instantiate;
+import org.apache.felix.ipojo.annotations.Provides;
+
+import java.util.logging.Logger;
+
+/**
+ * A component exposing itself as a verticle in the service registry, and creating a HTTP client to consume a web
+ * page.
+ */
+@Component
+@Provides
+@Instantiate
+public class VertxHttpClientVerticle extends AbstractVerticle {
+
+  private final static Logger LOGGER = Logger.getLogger("VertxHttpClientVerticle");
+
+  @Override
+  public void start() throws Exception {
+    getVertx().createHttpClient().getNow("perdu.com", "/", response -> {
+      response.bodyHandler(buffer -> LOGGER.info(buffer.toString("UTF-8")));
+    });
+  }
+}

--- a/osgi-examples/src/main/java/io/vertx/example/osgi/VertxHttpServer.java
+++ b/osgi-examples/src/main/java/io/vertx/example/osgi/VertxHttpServer.java
@@ -1,0 +1,38 @@
+package io.vertx.example.osgi;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import org.apache.felix.ipojo.annotations.*;
+
+import java.util.logging.Logger;
+
+/**
+ * A component creating a Vert.x HTTP Server.
+ */
+@Component(immediate = true)
+@Instantiate
+public class VertxHttpServer {
+
+  private final static Logger LOGGER = Logger.getLogger("VertxHttpServer");
+
+  @Requires
+  Vertx vertx;
+  private HttpServer server;
+
+  @Validate
+  public void start() {
+    LOGGER.info("Creating vertx HTTP server");
+    server = vertx.createHttpServer().requestHandler((r) -> {
+      r.response().end("Hello from OSGi !");
+    }).listen(8080);
+  }
+
+  @Invalidate
+  public void stop() {
+     if (server != null) {
+       server.close();
+     }
+  }
+
+
+}

--- a/osgi-examples/src/main/java/io/vertx/example/osgi/VertxVerticleHost.java
+++ b/osgi-examples/src/main/java/io/vertx/example/osgi/VertxVerticleHost.java
@@ -1,0 +1,37 @@
+package io.vertx.example.osgi;
+
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import org.apache.felix.ipojo.annotations.*;
+
+import java.util.logging.Logger;
+
+/**
+ * A component consuming all verticles exposed in the service registry and deploying them.
+ */
+@Component(immediate = true)
+@Instantiate
+public class VertxVerticleHost {
+
+  private final static Logger LOGGER = Logger.getLogger("VertxVerticleHost");
+
+  @Requires
+  Vertx vertx;
+
+  @Invalidate
+  public void stop() {
+    // We should unregister all deployed verticles.
+  }
+
+  @Bind(aggregate = true)
+  public void bindVerticle(Verticle verticle) {
+    LOGGER.info("Deploying verticle " + verticle);
+    vertx.deployVerticle(verticle);
+  }
+
+  @Unbind(aggregate = true)
+  public void unbindVerticle(Verticle verticle) {
+    LOGGER.info("Undeploying verticle " + verticle);
+    vertx.undeploy(verticle.getVertx().getOrCreateContext().deploymentID());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>unit-examples</module>
     <module>metrics-examples</module>
     <module>mail-examples</module>
+    <module>osgi-examples</module>
   </modules>
 
 


### PR DESCRIPTION
Add a few examples illustrating how Vert.x (core) can be used in an OSGi context.

This PR is related to https://github.com/eclipse/vert.x/pull/1058 and should only be merged once this one is merged.