### PR TITLE
use_${project_version}_in_favor_or_hardcoded_3_0_0-SNAPSHOT

### DIFF
--- a/docker-examples/vertx-docker-example-fabric8/pom.xml
+++ b/docker-examples/vertx-docker-example-fabric8/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/docker-examples/vertx-docker-example/pom.xml
+++ b/docker-examples/vertx-docker-example/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/docker-examples/vertx-docker-java-fatjar/pom.xml
+++ b/docker-examples/vertx-docker-java-fatjar/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/docker-examples/vertx-docker-java/pom.xml
+++ b/docker-examples/vertx-docker-java/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/mail-examples/pom.xml
+++ b/mail-examples/pom.xml
@@ -10,12 +10,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mail-client</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mail-service</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/maven-simplest/pom.xml
+++ b/maven-simplest/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/maven-verticle/pom.xml
+++ b/maven-verticle/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- Add hazelcast deps if you want it clusterable -->

--- a/openshift-example/pom.xml
+++ b/openshift-example/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- Add hazelcast deps if you want it clusterable -->

--- a/osgi-examples/pom.xml
+++ b/osgi-examples/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>osgi-examples</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
 
   <packaging>bundle</packaging>
 
@@ -19,7 +18,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I change pom.xml to refer to project.version instead of in some cases hardcoded value of 3.0.0-SNAPSHOT
It makes easier to switch to some version by "mvn versions:set" and get all i.e. using milestone6