### PR TITLE
Upgrade shadow plugin to 1.2.2

### DIFF
--- a/gradle-simplest/build.gradle
+++ b/gradle-simplest/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.1.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
     }
 }
 


### PR DESCRIPTION
Version 1.1.1 caused a StackOverflowError in my project:

Caused by: java.lang.StackOverflowError
      at org.gradle.api.tasks.bundling.Jar.manifest(Jar.groovy:29)
      at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.super$8$manifest(ShadowJar.groovy)
      at org.gradle.api.tasks.bundling.Jar.manifest(Jar.groovy:29)
      at com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.super$8$manifest(ShadowJar.groovy)
      at org.gradle.api.tasks.bundling.Jar.manifest(Jar.groovy:29)
...

With version 1.2.2 this problem is gone.