### PR TITLE
Add configuration support to codetrans

### DIFF
--- a/examples-utils/src/main/java/io/vertx/example/util/CodeTransProcessor.java
+++ b/examples-utils/src/main/java/io/vertx/example/util/CodeTransProcessor.java
@@ -1,5 +1,10 @@
 package io.vertx.example.util;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.codegen.Case;
 import io.vertx.codetrans.CodeTranslator;
 import io.vertx.codetrans.Lang;
@@ -12,11 +17,7 @@ import io.vertx.core.Verticle;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
@@ -24,32 +25,40 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A processor plugin generate scripts from {@link io.vertx.core.Verticle} class. It scans all the compiled
  * classes and tries to generate corresponding scripts for each class.<p/>
- *
+ * <p>
  * The script is named after the verticle fqn using the last atom of the package name and the lower
  * cased class name, for example : {@code examples.http.Server} maps to {@code http/server.js},
  * {@code http/server.groovy}, etc...<p/>
- *
+ * <p>
  * The processor is only active when the option {@code codetrans.output} is set to a valid directory where the scripts
  * will be written. A log <i>codetrans.log</i> will also be written with the processor activity.
+ * <p>
+ * The processor can be configured using the {@code condetrans.config} property targeting a JSON file. The JSON file
+ * contains a set of exclusions and is structured as follows:
+ * <p>
+ * <code><pre>
+ *     {
+ *       "excludes": [
+ *        {
+ *          "package" : "the (java) package to exclude",
+ *          "langs" : ["lang1", "lang2"]
+ *        }
+ *       ]
+ *     }
+ * </pre></code>
+ * <p>
+ * The {@code package} element is mandatory. {@code Langs} is optional. When not set, all languages are skipped.
+ * Languages are identified by their <em>extensions</em>.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author <a href="mailto:clement@apache.org">Clement Escoffier</a>
  */
 public class CodeTransProcessor extends AbstractProcessor {
 
@@ -58,6 +67,7 @@ public class CodeTransProcessor extends AbstractProcessor {
   private List<Lang> langs;
   private Set<File> folders = new HashSet<>(); // The copied folders so we don't do the job twice
   private PrintWriter log;
+  private ObjectNode config;
 
   @Override
   public Set<String> getSupportedOptions() {
@@ -78,6 +88,20 @@ public class CodeTransProcessor extends AbstractProcessor {
     }
     translator = new CodeTranslator(processingEnv);
     langs = Arrays.asList(new JavaScriptLang(), new GroovyLang(), new RubyLang());
+
+    String configFile = processingEnv.getOptions().get("codetrans.config");
+    if (configFile != null) {
+      ObjectMapper mapper = new ObjectMapper()
+          .enable(JsonParser.Feature.ALLOW_COMMENTS)
+          .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+      File file = new File(configFile);
+      try {
+        config = (ObjectNode) mapper.readTree(file);
+      } catch (IOException e) {
+        System.err.println("[ERROR] Cannot read configuration file " + file.getAbsolutePath() + " : " + e.getMessage());
+        e.printStackTrace();
+      }
+    }
   }
 
   private PrintWriter getLogger() throws Exception {
@@ -96,12 +120,13 @@ public class CodeTransProcessor extends AbstractProcessor {
         @Override
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
           Path targetPath = dstPath.resolve(srcPath.relativize(dir));
-          if(!Files.exists(targetPath)){
+          if (!Files.exists(targetPath)) {
             log.println("Creating dir " + targetPath);
             Files.createDirectory(targetPath);
           }
           return FileVisitResult.CONTINUE;
         }
+
         @Override
         public FileVisitResult visitFile(Path srcFile, BasicFileAttributes attrs) throws IOException {
           if (!srcFile.getFileName().toString().endsWith(".java")) {
@@ -161,6 +186,11 @@ public class CodeTransProcessor extends AbstractProcessor {
           File srcFolder = new File(obj.toUri()).getParentFile();
           String filename = Case.SNAKE.format(Case.CAMEL.parse(typeElt.getSimpleName().toString()));
           for (Lang lang : langs) {
+            if (isSkipped(typeElt, lang)) {
+              log.write("Skipping " + lang.getExtension() + " translation for " + typeElt.getQualifiedName() + "#" +
+                  methodElt.getSimpleName());
+              continue;
+            }
             String folderPath = processingEnv.getElementUtils().getPackageOf(typeElt).getQualifiedName().toString().replace('.', '/');
             File dstFolder = new File(new File(outputDir, lang.getExtension()), folderPath);
             if (dstFolder.exists() || dstFolder.mkdirs()) {
@@ -178,11 +208,54 @@ public class CodeTransProcessor extends AbstractProcessor {
           }
         }
       } catch (Exception e) {
-        e.printStackTrace();;
+        e.printStackTrace();
       }
       return true;
     } else {
       return false;
     }
+  }
+
+  /**
+   * Checks whether the generation of the given class to the given lang is explicitly excluded. Exclusions are
+   * managed in the configuration file. If no configuration file are provided, the translation is not skipped.
+   *
+   * @param type the type
+   * @param lang the language
+   * @return {@code true} if the translation is skipped, {@code false} otherwise.
+   */
+  private boolean isSkipped(TypeElement type, Lang lang) {
+    if (config == null) {
+      // no config, no exclusions
+      return false;
+    }
+    ArrayNode excludes = (ArrayNode) config.get("excludes");
+    for (JsonNode exclude : excludes) {
+      // Structure:
+      // {
+      //   "package": "the package to exclude", (mandatory)
+      //   "langs": ["lang 1", "lang 2"]
+      // }
+      // If not langs - skip all languages
+      String pck = exclude.get("package").asText();
+      ArrayNode langs = (ArrayNode) exclude.get("langs");
+      if (type.getQualifiedName().toString().startsWith(pck) && isLanguageSkipped(langs, lang)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isLanguageSkipped(ArrayNode langs, Lang lang) {
+    if (langs == null) {
+      // If not langs, exclude all.
+      return true;
+    }
+    for (JsonNode node : langs) {
+      if (node.asText().equalsIgnoreCase(lang.getExtension())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/examples-utils/src/main/java/io/vertx/example/util/CodeTransProcessor.java
+++ b/examples-utils/src/main/java/io/vertx/example/util/CodeTransProcessor.java
@@ -218,7 +218,7 @@ public class CodeTransProcessor extends AbstractProcessor {
 
   /**
    * Checks whether the generation of the given class to the given lang is explicitly excluded. Exclusions are
-   * managed in the configuration file. If no configuration file are provided, the translation is not skipped.
+   * managed in the configuration file. If no configuration file is provided, the translation is not skipped.
    *
    * @param type the type
    * @param lang the language
@@ -237,6 +237,12 @@ public class CodeTransProcessor extends AbstractProcessor {
       //   "langs": ["lang 1", "lang 2"]
       // }
       // If not langs - skip all languages
+
+      if (exclude.get("package") == null) {
+        throw new IllegalStateException("Malformed configuration - Missing 'package' attribute in the 'codetrans" +
+            ".config' file");
+      }
+
       String pck = exclude.get("package").asText();
       ArrayNode langs = (ArrayNode) exclude.get("langs");
       if (type.getQualifiedName().toString().startsWith(pck) && isLanguageSkipped(langs, lang)) {


### PR DESCRIPTION
In order to avoid the generation of examples that does not actually work as expected, we need a way to configure codetrans to _skip_ the generation of these example.

This PR adds this features. It provide a way to configure codetrans using the `codetrans.config` argument pointing to a JSON file.

The JSON file is structured as follows:

```
      {
        "excludes": [
         {
           "package" : "the (java) package to exclude",
           "langs" : ["lang1", "lang2"]
         }
        ]
      }
```

The `package` element is mandatory. It includes the specified packages and sub-packages. `Langs` is optional. When not set, all languages are skipped. Languages are identified by their _extensions_.

The "langs" option is useful as some examples are working as expected except in JavaScript.