### PR TITLE
Fix Spring Boot example so that we're actually using Spring Boot.

### DIFF
--- a/spring-examples/springboot-example/pom.xml
+++ b/spring-examples/springboot-example/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/spring-examples/springboot-example/src/main/java/io/vertx/example/Application.java
+++ b/spring-examples/springboot-example/src/main/java/io/vertx/example/Application.java
@@ -2,9 +2,9 @@ package io.vertx.example;
 
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.StaticHandler;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class Application {
@@ -13,16 +13,12 @@ public class Application {
 
     // This is basically the same example as the web-examples staticsite example but it's booted using
     // SpringBoot, not Vert.x
+    SpringApplication.run(Application.class, args);
+  }
 
-    Vertx vertx = Vertx.vertx();
-
-    Router router = Router.router(vertx);
-
-    // Serve the static pages
-    router.route().handler(StaticHandler.create());
-
-    vertx.createHttpServer().requestHandler(router::accept).listen(8080);
-
+  @Bean
+  public Vertx vertx(){
+      return Vertx.vertx();
   }
 
 }

--- a/spring-examples/springboot-example/src/main/java/io/vertx/example/StaticServer.java
+++ b/spring-examples/springboot-example/src/main/java/io/vertx/example/StaticServer.java
@@ -1,0 +1,33 @@
+package io.vertx.example;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.StaticHandler;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+/**
+ * Created by rworsnop on 8/31/15.
+ */
+@Component
+public class StaticServer {
+
+    private Vertx vertx;
+
+    @Resource
+    public void setVertx(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    @PostConstruct
+    public void createServer(){
+        Router router = Router.router(vertx);
+
+        // Serve the static pages
+        router.route().handler(StaticHandler.create());
+
+        vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+    }
+}


### PR DESCRIPTION
I'm up to date with my CLA.

This fixes the Spring Boot example so it actually uses Spring Boot (now you see the Spring Boot logo when you run it).

Because we are now actually using Spring Boot, we need to switch out the spring-boot-starter-web dependency, replacing it with just plain spring-boot-starter. Otherwise Spring Boot fires up embedded Tomcat, trying to listen on the same port as our Vert.x application.

I pulled the Vertx object out into a separate bean to make mocking easier (for people who base their apps on this model).