### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-examples/vertx-docker-java-fatjar/Dockerfile
+++ b/docker-examples/vertx-docker-java-fatjar/Dockerfile
@@ -6,7 +6,7 @@
 #   docker run -t -i -p 8080:8080 sample/vertx-java-fat
 ###
 
-FROM java:8
+FROM java:8-jre
 
 ENV VERTICLE_FILE hello-verticle-fatjar-3.2.1-fat.jar
 


### PR DESCRIPTION
Why not use `java:8-jre` instead of `java:8` which is JDK and image size is double of `java:8-jre`.