### PR TITLE
added example for mail with inline image

### DIFF
--- a/mail-examples/README.adoc
+++ b/mail-examples/README.adoc
@@ -45,3 +45,10 @@ This test uses a SSL connect to the mail server using Port 465 (which is
 actually deprecated, but is supported by many mail servers e.g. googlemail
 and AOL support port 465). The preferred way to send secure mails is TLS
 required and port 587.
+
+== link:src/main/java/io/vertx/example/mail/MailImages.java[MailImages]
+
+Send a mail with inline images
+
+This test sends a HTML mail with an inline image referenced in the html text by
+Content-ID.

--- a/mail-examples/src/main/groovy/io/vertx/example/mail/mail_images.groovy
+++ b/mail-examples/src/main/groovy/io/vertx/example/mail/mail_images.groovy
@@ -1,0 +1,33 @@
+import io.vertx.groovy.ext.mail.MailClient
+import io.vertx.groovy.core.MultiMap
+
+def mailClient = MailClient.createShared(vertx, [:])
+
+def email = [
+  from:"user@example.com (Sender)",
+  to:"user@example.com (User Name)",
+  subject:"Test email",
+  text:"full message is readable as html only",
+  html:"visit vert.x <a href=\"http://vertx.io/\"><img src=\"cid:image1@example.com\"></a>"
+]
+
+def list = []
+def attachment = [:]
+attachment.data = vertx.fileSystem().readFileBlocking("logo-white-big.png")
+attachment.contentType = "image/png"
+attachment.name = "logo-white-big.png"
+attachment.disposition = "inline"
+def headers = MultiMap.caseInsensitiveMultiMap()
+headers.add("Content-ID", "<image1@example.com>")
+attachment.headers = headers
+list.add(attachment)
+email.inlineAttachment = list
+
+mailClient.sendMail(email, { result ->
+  if (result.succeeded()) {
+    println(result.result())
+  } else {
+    println("got exception")
+    result.cause().printStackTrace()
+  }
+})

--- a/mail-examples/src/main/java/io/vertx/example/mail/MailHeaders.java
+++ b/mail-examples/src/main/java/io/vertx/example/mail/MailHeaders.java
@@ -2,7 +2,6 @@ package io.vertx.example.mail;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.example.util.Runner;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.MailMessage;
@@ -26,7 +25,6 @@ public class MailHeaders extends AbstractVerticle {
     Runner.runExample(MailHeaders.class);
   }
 
-
   public void start() {
     MailConfig mailConfig = new MailConfig().setHostname("smtp.example.com").setPort(465).setSsl(true);
 
@@ -39,7 +37,7 @@ public class MailHeaders extends AbstractVerticle {
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();
 
     headers.add("X-Mailer", "Vert.x Mail-Client 3.2.1");
-    headers.add("Message-ID", "12345@example.com");
+    headers.add("Message-ID", "<12345@example.com>");
     headers.add("Reply-To", "reply@example.com");
     headers.add("Received", "by vertx mail service");
     headers.add("Received", "from [192.168.1.1] by localhost");

--- a/mail-examples/src/main/java/io/vertx/example/mail/MailImages.java
+++ b/mail-examples/src/main/java/io/vertx/example/mail/MailImages.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.MultiMap;
 import io.vertx.example.util.Runner;
 import io.vertx.ext.mail.MailAttachment;
 import io.vertx.ext.mail.MailClient;
@@ -32,10 +32,9 @@ public class MailImages extends AbstractVerticle {
     MailMessage email = new MailMessage()
         .setFrom("user@example.com (Sender)")
         .setTo("user@example.com (User Name)")
-        .setBounceAddress("user@example.com (Bounce)")
         .setSubject("Test email")
         .setText("full message is readable as html only")
-        .setHtml("visit vert.x <a href=\"\"><img src=\"cid:image1@example.com\"></a>");
+        .setHtml("visit vert.x <a href=\"http://vertx.io/\"><img src=\"cid:image1@example.com\"></a>");
 
     List<MailAttachment> list=new ArrayList<>();
     MailAttachment attachment = new MailAttachment();
@@ -43,7 +42,9 @@ public class MailImages extends AbstractVerticle {
     attachment.setContentType("image/png");
     attachment.setName("logo-white-big.png");
     attachment.setDisposition("inline");
-    attachment.setHeaders(new CaseInsensitiveHeaders().add("Content-ID", "<image1@example.com>"));
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Content-ID", "<image1@example.com>");
+    attachment.setHeaders(headers);
     list.add(attachment);
     email.setInlineAttachment(list);
 

--- a/mail-examples/src/main/java/io/vertx/example/mail/MailImages.java
+++ b/mail-examples/src/main/java/io/vertx/example/mail/MailImages.java
@@ -1,0 +1,60 @@
+package io.vertx.example.mail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.example.util.Runner;
+import io.vertx.ext.mail.MailAttachment;
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.MailMessage;
+
+/**
+ * send a mail with HTML and inline images
+ *
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
+ */
+public class MailImages extends AbstractVerticle {
+
+  // Convenience method so you can run it in your IDE
+  public static void main(String[] args) {
+    Runner.runExample(MailImages.class);
+  }
+
+  @Override
+  public void start() {
+
+    MailClient mailClient = MailClient.createShared(vertx, new MailConfig());
+
+    MailMessage email = new MailMessage()
+        .setFrom("user@example.com (Sender)")
+        .setTo("user@example.com (User Name)")
+        .setBounceAddress("user@example.com (Bounce)")
+        .setSubject("Test email")
+        .setText("full message is readable as html only")
+        .setHtml("visit vert.x <a href=\"\"><img src=\"cid:image1@example.com\"></a>");
+
+    List<MailAttachment> list=new ArrayList<>();
+    MailAttachment attachment = new MailAttachment();
+    attachment.setData(vertx.fileSystem().readFileBlocking("logo-white-big.png"));
+    attachment.setContentType("image/png");
+    attachment.setName("logo-white-big.png");
+    attachment.setDisposition("inline");
+    attachment.setHeaders(new CaseInsensitiveHeaders().add("Content-ID", "<image1@example.com>"));
+    list.add(attachment);
+    email.setInlineAttachment(list);
+
+    mailClient.sendMail(email, result -> {
+      if (result.succeeded()) {
+        System.out.println(result.result());
+      } else {
+        System.out.println("got exception");
+        result.cause().printStackTrace();
+      }
+    });
+  }
+
+}

--- a/mail-examples/src/main/js/io/vertx/example/mail/mail_images.js
+++ b/mail-examples/src/main/js/io/vertx/example/mail/mail_images.js
@@ -1,0 +1,35 @@
+var MailClient = require("vertx-mail-js/mail_client");
+var MultiMap = require("vertx-js/multi_map");
+
+var mailClient = MailClient.createShared(vertx, {
+});
+
+var email = {
+  "from" : "user@example.com (Sender)",
+  "to" : "user@example.com (User Name)",
+  "subject" : "Test email",
+  "text" : "full message is readable as html only",
+  "html" : "visit vert.x <a href=\"http://vertx.io/\"><img src=\"cid:image1@example.com\"></a>"
+};
+
+var list = [];
+var attachment = {
+};
+attachment.data = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+attachment.contentType = "image/png";
+attachment.name = "logo-white-big.png";
+attachment.disposition = "inline";
+var headers = MultiMap.caseInsensitiveMultiMap();
+headers.add("Content-ID", "<image1@example.com>");
+attachment.headers = headers;
+list.push(attachment);
+email.inlineAttachment = list;
+
+mailClient.sendMail(email, function (result, result_err) {
+  if (result_err == null) {
+    console.log(result);
+  } else {
+    console.log("got exception");
+    result_err.printStackTrace();
+  }
+});

--- a/mail-examples/src/main/rb/io/vertx/example/mail/mail_images.rb
+++ b/mail-examples/src/main/rb/io/vertx/example/mail/mail_images.rb
@@ -1,0 +1,35 @@
+require 'vertx-mail/mail_client'
+require 'vertx/multi_map'
+
+mailClient = VertxMail::MailClient.create_shared($vertx, {
+})
+
+email = {
+  'from' => "user@example.com (Sender)",
+  'to' => "user@example.com (User Name)",
+  'subject' => "Test email",
+  'text' => "full message is readable as html only",
+  'html' => "visit vert.x <a href=\"http://vertx.io/\"><img src=\"cid:image1@example.com\"></a>"
+}
+
+list = Array.new
+attachment = {
+}
+attachment['data'] = $vertx.file_system().read_file_blocking("logo-white-big.png")
+attachment['contentType'] = "image/png"
+attachment['name'] = "logo-white-big.png"
+attachment['disposition'] = "inline"
+headers = Vertx::MultiMap.case_insensitive_multi_map()
+headers.add("Content-ID", "<image1@example.com>")
+attachment['headers'] = headers
+list.push(attachment)
+email['inlineAttachment'] = list
+
+mailClient.send_mail(email) { |result_err,result|
+  if (result_err == nil)
+    puts result
+  else
+    puts "got exception"
+    result_err.print_stack_trace()
+  end
+}


### PR DESCRIPTION
I have added the example for vertx-mail-client#66
build the examples against 3.3.0-SNAPSHOT didn't work for so this is currently only present for java