### PR TITLE
Update README.adoc

### DIFF
--- a/ceylon/README.adoc
+++ b/ceylon/README.adoc
@@ -19,6 +19,13 @@ For more info please refer to http://vertx.io/docs/
 === Usage from Ceylon
 
 ----
+From the "ceylon" directory. Only once.
+
+> ceylon compile examples.utils
+Note: Created module examples.utils/1.0.0
+----
+
+----
 > ceylon compile examples.core.http.simple.server
 Note: Created module examples.core.http.simple.server/1.0.0
 


### PR DESCRIPTION
workaround regarding 

> Vert.x 3.2.0 doesn't run ceylon examples #117

As vietj commented on 28 Jan

> hi, actually there is one step not explaiend in the doc when using "vertx run" is that the module "examples.utils/1.0.0" should be deployed in the module repository. can you try ?