### PR TITLE
Add multiple eventbus consumers to the address

### DIFF
--- a/core-examples/src/main/java/io/vertx/example/core/eventbus/pubsub/Receiver.java
+++ b/core-examples/src/main/java/io/vertx/example/core/eventbus/pubsub/Receiver.java
@@ -20,7 +20,11 @@ public class Receiver extends AbstractVerticle {
 
     EventBus eb = vertx.eventBus();
 
-    eb.consumer("news-feed", message -> System.out.println("Received news: " + message.body()));
+    eb.consumer("news-feed", message -> System.out.println("Received news on consumer 1: " + message.body()));
+    
+    eb.consumer("news-feed", message -> System.out.println("Received news on consumer 2: " + message.body()));
+    
+    eb.consumer("news-feed", message -> System.out.println("Received news on consumer 3: " + message.body()));
 
     System.out.println("Ready!");
   }


### PR DESCRIPTION
This makes it clear to new users that messages 'published' on eventBus will reach all consumers subscribed to that address.