### PR TITLE
encodePrettily cause the code to be called twice

### DIFF
--- a/osgi-examples/src/main/java/io/vertx/example/osgi/VertxWebApplication.java
+++ b/osgi-examples/src/main/java/io/vertx/example/osgi/VertxWebApplication.java
@@ -71,7 +71,7 @@ public class VertxWebApplication extends AbstractVerticle {
       if (product == null) {
         sendError(404, response);
       } else {
-        response.putHeader("content-type", "application/json").end(product.encodePrettily());
+        response.putHeader("content-type", "application/json").end(product.encode());
       }
     }
   }


### PR DESCRIPTION
I used a logger and found the route is called twice. I opened a bug on vertx-web.
its about 5 ms slower (on my machine with the logger) 9 ms instead of 4 ms
there are other places this can be fixed in this code sample.