### PR TITLE
Spring worker example

### DIFF
--- a/spring-examples/README.adoc
+++ b/spring-examples/README.adoc
@@ -17,3 +17,7 @@ The link:spring-boot-clustering/README.adoc[Spring Boot Clustering Examples] sho
 == Spring Verticle Factory
 
 The link:spring-verticle-factory/README.adoc[Spring Verticle Factory Example] shows how you can build a Verticle factory based on the Spring container.
+
+== Spring Worker Example
+
+The link:spring-worker-example/README.adoc[Vert.x Spring Worker Example] shows how you how to expose Spring services over the event bus with worker verticles.

--- a/spring-examples/pom.xml
+++ b/spring-examples/pom.xml
@@ -15,6 +15,7 @@
     <module>spring-example</module>
     <module>springboot-clustering</module>
     <module>spring-verticle-factory</module>
+    <module>spring-worker-example</module>
   </modules>
 
 </project>

--- a/spring-examples/spring-worker-example/README.adoc
+++ b/spring-examples/spring-worker-example/README.adoc
@@ -1,0 +1,33 @@
+= Vert.x Spring Worker example
+
+This example shows how you can embed Vert.x in Spring Boot, having:
+
+- Spring container creating the verticles
+- a standard verticle with Vert.x web for the REST API
+- Spring backend services (with declarative transaction management and JPA repositories)
+- a worker verticle exposing the Spring services over the event bus through service proxies
+
+This might be useful if you have an existing Spring codebase and want to keep your data access layer.
+
+To try the example, execute this command in a terminal:
+
+[source,shell]
+----
+mvn clean spring-boot:run
+----
+
+Then add a book to the database:
+
+[source,shell]
+----
+curl http://localhost:8080/book --data '{"name": "The Practice of System and Network Administration", "author":"Thomas A. Limoncelli, Christina J. Hn, Strata R. Chalup"}'
+----
+
+You should now be able to see your book saved:
+
+[source,shell]
+----
+curl http://localhost:8080/books
+----
+
+Notice that the `id` field is now set which means that the book as indeed been persisted in the database.

--- a/spring-examples/spring-worker-example/pom.xml
+++ b/spring-examples/spring-worker-example/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>spring-examples</artifactId>
+    <version>3.3.3</version>
+  </parent>
+
+  <artifactId>spring-worker-example</artifactId>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+    <boot.version>1.4.3.RELEASE</boot.version>
+    <h2.version>1.4.191</h2.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${h2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-service-proxy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- We specify the Maven compiler plugin as we need to set it to Java 1.8 -->
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+            <annotationProcessors>
+              <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
+            </annotationProcessors>
+            <compilerArgs>
+              <arg>-AoutputDirectory=${project.basedir}/src/main</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>staging</id>
+      <repositories>
+        <repository>
+          <id>staging</id>
+          <url>https://oss.sonatype.org/content/repositories/iovertx-3295</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</project>

--- a/spring-examples/spring-worker-example/src/main/asciidoc/dataobjects.adoc
+++ b/spring-examples/spring-worker-example/src/main/asciidoc/dataobjects.adoc
@@ -1,0 +1,19 @@
+= Cheatsheets
+
+[[Book]]
+== Book
+
+++++
+ A book JPA entity.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[author]]`author`|`String`|-
+|[[id]]`id`|`Number (Long)`|-
+|[[name]]`name`|`String`|-
+|===
+

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/Application.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/Application.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.*;
+
+/**
+ * @author Thomas Segismont
+ */
+@SpringBootApplication
+public class Application {
+  private static final Logger LOG = LoggerFactory.getLogger(Application.class);
+
+  @Autowired
+  SpringVerticleFactory verticleFactory;
+
+  /**
+   * The Vert.x worker pool size, configured in the {@code application.properties} file.
+   *
+   * Make sure this is greater than {@link #springWorkerInstances}.
+   */
+  @Value("${vertx.worker.pool.size}")
+  int workerPoolSize;
+
+  /**
+   * The number of {@link SpringWorker} instances to deploy, configured in the {@code application.properties} file.
+   */
+  @Value("${vertx.springWorker.instances}")
+  int springWorkerInstances;
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+  /**
+   * Deploy verticles when the Spring application is ready.
+   */
+  @EventListener
+  public void deployVerticles(ApplicationReadyEvent event) {
+    Vertx vertx = Vertx.vertx(new VertxOptions().setWorkerPoolSize(workerPoolSize));
+
+    // The verticle factory is registered manually because it is created by the Spring container
+    vertx.registerVerticleFactory(verticleFactory);
+
+    CountDownLatch deployLatch = new CountDownLatch(2);
+    AtomicBoolean failed = new AtomicBoolean(false);
+
+    String restApiVerticleName = verticleFactory.prefix() + ":" + BookRestApi.class.getName();
+    vertx.deployVerticle(restApiVerticleName, ar -> {
+      if (ar.failed()) {
+        LOG.error("Failed to deploy verticle", ar.cause());
+        failed.compareAndSet(false, true);
+      }
+      deployLatch.countDown();
+    });
+
+    DeploymentOptions workerDeploymentOptions = new DeploymentOptions()
+      .setWorker(true)
+      // As worker verticles are never executed concurrently by Vert.x by more than one thread,
+      // deploy multiple instances to avoid serializing requests.
+      .setInstances(springWorkerInstances);
+    String workerVerticleName = verticleFactory.prefix() + ":" + SpringWorker.class.getName();
+    vertx.deployVerticle(workerVerticleName, workerDeploymentOptions, ar -> {
+      if (ar.failed()) {
+        LOG.error("Failed to deploy verticle", ar.cause());
+        failed.compareAndSet(false, true);
+      }
+      deployLatch.countDown();
+    });
+
+    try {
+      if (!deployLatch.await(5, SECONDS)) {
+        throw new RuntimeException("Timeout waiting for verticle deployments");
+      } else if (failed.get()) {
+        throw new RuntimeException("Failure while deploying verticles");
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/Book.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/Book.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * A book JPA entity.
+ *
+ * @author Thomas Segismont
+ */
+@Entity
+// Book must annotated with @DataObject because it is used as a parameter type in BookAsyncService
+@DataObject(generateConverter = true)
+public class Book {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  private String name;
+
+  private String author;
+
+  // Mandatory for JPA entities
+  protected Book() {
+  }
+
+  public Book(String name, String author) {
+    this.name = name;
+    this.author = author;
+  }
+
+  // Mandatory for data objects
+  public Book(JsonObject jsonObject) {
+    BookConverter.fromJson(jsonObject, this);
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public void setAuthor(String author) {
+    this.author = author;
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    BookConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public String toString() {
+    return "Book{" +
+      "id=" + id +
+      ", name='" + name + '\'' +
+      ", author='" + author + '\'' +
+      '}';
+  }
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookAsyncService.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookAsyncService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+import java.util.List;
+
+/**
+ * Describes a service exposed on the event bus with <a href="http://vertx.io/docs/vertx-service-proxy/java/">Vert.x Service Proxies</a>.
+ *
+ * @author Thomas Segismont
+ */
+@ProxyGen
+public interface BookAsyncService {
+
+  /**
+   * The service address on the Vert.x event bus.
+   */
+  String ADDRESS = BookAsyncService.class.getName();
+
+  void add(Book book, Handler<AsyncResult<Book>> resultHandler);
+
+  void getAll(Handler<AsyncResult<List<Book>>> resultHandler);
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookAsyncServiceImpl.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookAsyncServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Implements the {@link BookAsyncService}, delegating calls to the transactional {@link BookService}.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+public class BookAsyncServiceImpl implements BookAsyncService {
+
+  @Autowired
+  BookService bookService;
+
+  @Override
+  public void add(Book book, Handler<AsyncResult<Book>> resultHandler) {
+    Book saved = bookService.save(book);
+    Future.succeededFuture(saved).setHandler(resultHandler);
+  }
+
+  @Override
+  public void getAll(Handler<AsyncResult<List<Book>>> resultHandler) {
+    List<Book> all = bookService.getAll();
+    Future.succeededFuture(all).setHandler(resultHandler);
+  }
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRepository.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * A {@link CrudRepository} for our {@link Book} entity.
+ *
+ * @author Thomas Segismont
+ */
+public interface BookRepository extends CrudRepository<Book, Long> {
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRestApi.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRestApi.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.StaticHandler;
+import io.vertx.serviceproxy.ProxyHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.net.HttpURLConnection.*;
+
+/**
+ * A standard verticle, consuming the {@link BookAsyncService} over the event bus to expose a REST API.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+public class BookRestApi extends AbstractVerticle {
+  private static final Logger LOG = LoggerFactory.getLogger(BookRestApi.class);
+
+  private BookAsyncService bookAsyncService;
+
+  @Override
+  public void start(Future<Void> startFuture) throws Exception {
+    bookAsyncService = ProxyHelper.createProxy(BookAsyncService.class, vertx, BookAsyncService.ADDRESS);
+
+    Router router = Router.router(vertx);
+
+    router.route().handler(BodyHandler.create());
+
+    router.post("/book").handler(this::addBook);
+    router.get("/books").handler(this::getAllBooks);
+
+    StaticHandler staticHandler = StaticHandler.create();
+    router.route().handler(staticHandler);
+
+    vertx.createHttpServer().requestHandler(router::accept).listen(8080, listen -> {
+      if (listen.succeeded()) {
+        LOG.info("BookRestApi started");
+        startFuture.complete();
+      } else {
+        startFuture.fail(listen.cause());
+      }
+    });
+  }
+
+  private void addBook(RoutingContext routingContext) {
+    Book book = new Book(routingContext.getBodyAsJson());
+    bookAsyncService.add(book, ar -> {
+      if (ar.succeeded()) {
+        routingContext.response().setStatusCode(HTTP_CREATED).end();
+      } else {
+        routingContext.fail(ar.cause());
+      }
+    });
+  }
+
+  private void getAllBooks(RoutingContext routingContext) {
+    bookAsyncService.getAll(ar -> {
+      if (ar.succeeded()) {
+        List<Book> result = ar.result();
+        JsonArray jsonArray = new JsonArray(result);
+        routingContext.response().end(jsonArray.encodePrettily());
+      } else {
+        routingContext.fail(ar.cause());
+      }
+    });
+  }
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookService.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * A classical transactional service facade.
+ *
+ * @author Thomas Segismont
+ */
+@Service
+@Transactional
+public class BookService {
+
+  @Autowired
+  BookRepository bookRepository;
+
+  public Book save(Book book) {
+    return bookRepository.save(book);
+  }
+
+  public List<Book> getAll() {
+    Iterable<Book> all = bookRepository.findAll();
+    return StreamSupport.stream(all.spliterator(), false).collect(toList());
+  }
+
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringVerticleFactory.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringVerticleFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.core.Verticle;
+import io.vertx.core.spi.VerticleFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * A {@link VerticleFactory} backed by Spring's {@link ApplicationContext}. It allows to implement verticles as Spring
+ * beans and thus benefit from dependency injection, ...etc.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+public class SpringVerticleFactory implements VerticleFactory, ApplicationContextAware {
+
+  private ApplicationContext applicationContext;
+
+  @Override
+  public boolean blockingCreate() {
+    // Usually verticle instantiation is fast but since our verticles are Spring Beans,
+    // they might depend on other beans/resources which are slow to build/lookup.
+    return true;
+  }
+
+  @Override
+  public String prefix() {
+    // Just an arbitrary string which must uniquely identify the verticle factory
+    return "myapp";
+  }
+
+  @Override
+  public Verticle createVerticle(String verticleName, ClassLoader classLoader) throws Exception {
+    // Our convention in this example is to give the class name as verticle name
+    String clazz = VerticleFactory.removePrefix(verticleName);
+    return (Verticle) applicationContext.getBean(Class.forName(clazz));
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+  }
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringWorker.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringWorker.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.example.spring.worker;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.serviceproxy.ProxyHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.*;
+
+/**
+ * A worker verticle, exposing the {@link BookAsyncService} over the event bus.
+ *
+ * Since it is a worker verticle, it is perfectly fine for the registered service to delegate calls to backend Spring beans.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+// Prototype scope is needed as multiple instances of this verticle will be deployed
+@Scope(SCOPE_PROTOTYPE)
+public class SpringWorker extends AbstractVerticle {
+  private static final Logger LOG = LoggerFactory.getLogger(SpringWorker.class);
+
+  @Autowired
+  BookAsyncService bookAsyncService;
+
+  @Override
+  public void start(Future<Void> startFuture) throws Exception {
+    ProxyHelper.registerService(BookAsyncService.class, vertx, bookAsyncService, BookAsyncService.ADDRESS).completionHandler(ar -> {
+      if (ar.succeeded()) {
+        LOG.info("SpringWorker started");
+        startFuture.complete();
+      } else {
+        startFuture.fail(ar.cause());
+      }
+    });
+  }
+
+}

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/package-info.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Vert.x codegen requires a {@code package-info.java} file annotated with {@link ModuleGen}.
+ *
+ * @author Thomas Segismont
+ */
+@ModuleGen(name = "example", groupPackage = "io.vertx.example.spring.worker")
+package io.vertx.example.spring.worker;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/spring-examples/spring-worker-example/src/main/resources/application.properties
+++ b/spring-examples/spring-worker-example/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+################### DataSource Configuration ##########################
+jdbc.driverClassName=org.h2.Driver
+jdbc.url=jdbc:h2:~/test
+jdbc.username=sa
+jdbc.password=
+################### Hibernate Configuration ##########################
+hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.show_sql=true
+hibernate.hbm2ddl.auto=validate
+################### Vert.x Configuration ##########################
+vertx.worker.pool.size=40
+vertx.springWorker.instances=20


### PR DESCRIPTION
This example shows how you can embed Vert.x in SpringBoot, having:

- Spring container creating the verticles
- a standard verticle with Vert.x web for the REST API
- Spring backend services (with declarative transaction management and JPA repositories)
- a worker verticle exposing the Spring services over the event bus through service proxies

This might be useful if you have an existing Spring codebase and want to keep your data access layer.