### PR TITLE
Adds a new Spring Boot clustering examples folder.

### DIFF
--- a/spring-examples/pom.xml
+++ b/spring-examples/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>springboot-example</module>
     <module>spring-example</module>
+    <module>springboot-clustering</module>
   </modules>
 
 </project>

--- a/spring-examples/springboot-clustering/README.adoc
+++ b/spring-examples/springboot-clustering/README.adoc
@@ -1,0 +1,5 @@
+= Spring Boot Clustering Examples
+
+These projects show how you can setup a clustered Vert.x embedded in Spring Boot, having the Spring container managing the clustering engine:
+
+* link:springboot-clustering-hazelcast/README.adoc[Spring Boot Hazelcast Clustering]

--- a/spring-examples/springboot-clustering/pom.xml
+++ b/spring-examples/springboot-clustering/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>spring-examples</artifactId>
+    <version>3.3.3</version>
+  </parent>
+
+  <artifactId>springboot-clustering</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>springboot-clustering-hazelcast</module>
+  </modules>
+
+</project>

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/README.adoc
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/README.adoc
@@ -1,0 +1,55 @@
+= Spring Boot Hazelcast Clustering
+
+This project shows how you can setup a clustered Vert.x embedded in Spring Boot, having the Spring container managing Hazelcast.
+
+It consists of two verticles.
+The first one starts an HTTP server, expecting a `name` query parameter, and sending it on the event bus.
+The second one listens to names sent on the event bus, and replies with a formatted message.
+Eventually the message goes to the client in the HTTP response body.
+
+== The code
+
+In the `io.vertx.examples.spring.clustering.hazelcast.VertxProducer` class, a clustered Vert.x instance is created.
+It uses a Spring-managed `com.hazelcast.core.HazelcastInstance`.
+
+There are multiple ways to configure it, but a simple one is to put a `hazelcast.xml` file at the root of the classpath.
+
+The Hazelcast instance will be created *before* and destroyed *after* Vert.x.
+
+IMPORTANT: the Hazelcast shutdown hook must be disabled.
+
+To disable it, simply add this to the `hazelcast.xml` file:
+
+[source,xml]
+----
+  <properties>
+    <!-- ... other properties ... -->
+    <property name="hazelcast.shutdownhook.enabled">false</property>
+  </properties>
+----
+
+== Trying
+
+To see clustering in action, you should start multiple instances of this application.
+The HTTP server will be setup only if you provide an `httpPort` system property.
+
+So you can start the first instance with an HTTP server on port 8081:
+
+[source,shell]
+----
+mvn spring-boot:run -DhttpPort=8081
+----
+
+And then start the other instances without the HTTP server:
+
+[source,shell]
+----
+mvn spring-boot:run
+----
+
+It's time for testing now:
+
+[source,shell]
+----
+seq 10 | while read i; do curl http://localhost:8081/?name=Thomas${i}; echo; done
+----

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/pom.xml
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>springboot-clustering</artifactId>
+    <version>3.3.3</version>
+  </parent>
+
+  <artifactId>springboot-clustering-hazelcast</artifactId>
+
+  <properties>
+    <boot.version>1.4.3.RELEASE</boot.version>
+    <vertx.version>${project.version}</vertx.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-hazelcast</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>staging</id>
+      <repositories>
+        <repository>
+          <id>staging</id>
+          <url>https://oss.sonatype.org/content/repositories/iovertx-3295</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</project>

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/Application.java
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/Application.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.clustering.hazelcast;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+
+/**
+ * @author Thomas Segismont
+ */
+@SpringBootApplication
+public class Application {
+
+  @Autowired
+  Vertx vertx;
+
+  @Value("${systemProperties.httpPort:#{null}}")
+  Integer port;
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+  /**
+   * Deploy verticles when the Spring application is ready.
+   */
+  @EventListener
+  void deployVerticles(ApplicationReadyEvent event) {
+    vertx.deployVerticle(new HelloVerticle());
+    if (port != null) {
+      JsonObject config = new JsonObject().put("port", port);
+      vertx.deployVerticle(new HttpVerticle(), new DeploymentOptions().setConfig(config));
+    }
+  }
+}

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/HelloVerticle.java
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/HelloVerticle.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.clustering.hazelcast;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+
+import java.util.UUID;
+
+/**
+ * @author Thomas Segismont
+ */
+public class HelloVerticle extends AbstractVerticle {
+  private static final String ID = UUID.randomUUID().toString();
+
+  @Override
+  public void start(Future<Void> startFuture) throws Exception {
+    vertx.eventBus().<String>consumer("hello", message -> {
+      message.reply("Hello " + message.body() + " from " + ID);
+    }).completionHandler(startFuture.completer());
+  }
+}

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/HttpVerticle.java
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/HttpVerticle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.clustering.hazelcast;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerOptions;
+
+/**
+ * @author Thomas Segismont
+ */
+public class HttpVerticle extends AbstractVerticle {
+
+  @Override
+  public void start(Future<Void> startFuture) throws Exception {
+    HttpServerOptions options = new HttpServerOptions().setPort(config().getInteger("port"));
+    vertx.createHttpServer(options).requestHandler(request -> {
+      String name = request.getParam("name");
+      if (name == null) {
+        request.response().setStatusCode(400).end("Missing name");
+      } else {
+        vertx.eventBus().<String>send("hello", name, ar -> {
+          if (ar.succeeded()) {
+            request.response().end(ar.result().body());
+          } else {
+            request.response().setStatusCode(500).end(ar.cause().getMessage());
+          }
+        });
+      }
+    }).listen(ar -> {
+      if (ar.succeeded()) {
+        startFuture.complete();
+      } else {
+        startFuture.fail(ar.cause());
+      }
+    });
+  }
+}

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/VertxProducer.java
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/java/io/vertx/examples/spring/clustering/hazelcast/VertxProducer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.clustering.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A component managing the lifecycle of the clustered Vert.x instance.
+ * It uses the Spring-managed {@link HazelcastInstance}.
+ *
+ * This bean is created <strong>after</strong> and destroyed <strong>before</strong> the {@link HazelcastInstance}.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+public class VertxProducer {
+
+  @Autowired
+  HazelcastInstance hazelcastInstance;
+
+  private Vertx vertx;
+
+  @PostConstruct
+  void init() throws ExecutionException, InterruptedException {
+    VertxOptions options = new VertxOptions()
+      .setClusterManager(new HazelcastClusterManager(hazelcastInstance));
+    CompletableFuture<Vertx> future = new CompletableFuture<>();
+    Vertx.clusteredVertx(options, ar -> {
+      if (ar.succeeded()) {
+        future.complete(ar.result());
+      } else {
+        future.completeExceptionally(ar.cause());
+      }
+    });
+    vertx = future.get();
+  }
+
+  /**
+   * Exposes the clustered Vert.x instance.
+   * We must disable destroy method inference, otherwise Spring will call the {@link Vertx#close()} automatically.
+   */
+  @Bean(destroyMethod = "")
+  Vertx vertx() {
+    return vertx;
+  }
+
+  @PreDestroy
+  void close() throws ExecutionException, InterruptedException {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(ar -> future.complete(null));
+    future.get();
+  }
+}

--- a/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/resources/hazelcast.xml
+++ b/spring-examples/springboot-clustering/springboot-clustering-hazelcast/src/main/resources/hazelcast.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">0</property>
+    <property name="hazelcast.shutdownhook.enabled">false</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>


### PR DESCRIPTION
For now it's Hazelcast only but we can add Infinispan when the module is ready.

The goal is to provide a pointer for users having problems with Spring-managed clustering engines.

In particular, it shows:

* how you can setup/close Vert.x after/before Hazelcast
* how you should configure Hazelcast to disable its shutdown hook