### PR TITLE
Adds a new Spring Verticle Factory example

### DIFF
--- a/spring-examples/README.adoc
+++ b/spring-examples/README.adoc
@@ -13,3 +13,7 @@ The link:spring-example/README.adoc[Vert.x Spring Example] shows how you can acc
 == Spring Boot Clustering
 
 The link:spring-boot-clustering/README.adoc[Spring Boot Clustering Examples] show how you can setup a clustered Vert.x embedded in Spring Boot.
+
+== Spring Verticle Factory
+
+The link:spring-verticle-factory/README.adoc[Spring Verticle Factory Example] shows how you can build a Verticle factory based on the Spring container.

--- a/spring-examples/pom.xml
+++ b/spring-examples/pom.xml
@@ -14,6 +14,7 @@
     <module>springboot-example</module>
     <module>spring-example</module>
     <module>springboot-clustering</module>
+    <module>spring-verticle-factory</module>
   </modules>
 
 </project>

--- a/spring-examples/spring-verticle-factory/README.adoc
+++ b/spring-examples/spring-verticle-factory/README.adoc
@@ -1,0 +1,56 @@
+= Spring Verticle Factory Example
+
+This project shows how you can build a Verticle factory based on the Spring container.
+
+Why not injecting a verticle instance and deploy it directly?
+Because Vert.x follows the Multi-Reactor pattern,
+so if you want to scale accross your server's CPU,
+you need to http://vertx.io/docs/vertx-core/java/#_specifying_number_of_verticle_instances[deploy multiple instances of your verticle].
+
+Only then Vert.x will guarantee that the instances run on separate event loops.
+
+== The code
+
+The `io.vertx.examples.spring.verticlefactory.SpringVerticleFactory` class is an `ApplicationContextAware` Spring component.
+It is given an `ApplicationContext` on startup and will use it to create verticle instances.
+As it is managed by the Spring container, it must be registered manually (usually one can do this via the Java service loaders).
+
+The `io.vertx.examples.spring.verticlefactory.SpringVerticleFactory` depends on a simple greeter component.
+It sets up an HttpServer and use the greeter to generate a hello message for the HTTP response.
+
+IMPORTANT: When you invoke Spring beans from standard verticles, remember that you must not call blocking code
+or you will block the event loop.
+
+== Trying
+
+
+In a terminal, compile and run the example:
+
+[source,shell]
+----
+mvn compile exec:java@run
+----
+
+Then in another tab or window, send a few requests to the server.
+
+[source,shell]
+----
+seq 10 | while read i; do curl http://localhost:8080/?name=Thomas${i}; echo; done
+----
+
+If you look at the console, you'll notice that the requests have indeed been managed by different event loops:
+
+[source]
+[subs="verbatim,quotes"]
+----
+12:46:02.661 [*vert.x-eventloop-thread-2*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas1
+12:46:02.685 [*vert.x-eventloop-thread-4*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas2
+12:46:02.698 [*vert.x-eventloop-thread-1*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas3
+12:46:02.711 [*vert.x-eventloop-thread-3*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas4
+12:46:02.722 [*vert.x-eventloop-thread-2*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas5
+12:46:02.733 [*vert.x-eventloop-thread-4*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas6
+12:46:02.748 [*vert.x-eventloop-thread-1*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas7
+12:46:02.761 [*vert.x-eventloop-thread-3*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas8
+12:46:02.773 [*vert.x-eventloop-thread-2*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas9
+12:46:02.785 [*vert.x-eventloop-thread-4*] INFO io.vertx.examples.spring.verticlefactory.GreetingVerticle - Got request for name: Thomas10
+----

--- a/spring-examples/spring-verticle-factory/pom.xml
+++ b/spring-examples/spring-verticle-factory/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>spring-examples</artifactId>
+    <version>3.3.3</version>
+  </parent>
+
+  <artifactId>spring-verticle-factory</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>4.3.5.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.20</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.7</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <executions>
+          <execution>
+            <id>run</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>io.vertx.examples.spring.verticlefactory.ExampleApplication</mainClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>staging</id>
+      <repositories>
+        <repository>
+          <id>staging</id>
+          <url>https://oss.sonatype.org/content/repositories/iovertx-3295</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</project>

--- a/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/ExampleApplication.java
+++ b/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/ExampleApplication.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.verticlefactory;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.spi.VerticleFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Thomas Segismont
+ */
+@Configuration
+@ComponentScan("io.vertx.examples.spring.verticlefactory")
+public class ExampleApplication {
+
+  public static void main(String[] args) {
+    Vertx vertx = Vertx.vertx();
+
+    ApplicationContext context = new AnnotationConfigApplicationContext(ExampleApplication.class);
+
+    VerticleFactory verticleFactory = context.getBean(SpringVerticleFactory.class);
+
+    // The verticle factory is registered manually because it is created by the Spring container
+    vertx.registerVerticleFactory(verticleFactory);
+
+    // Scale the verticles on cores: create 4 instances during the deployment
+    DeploymentOptions options = new DeploymentOptions().setInstances(4);
+    vertx.deployVerticle(verticleFactory.prefix() + ":" + GreetingVerticle.class.getName(), options);
+  }
+
+}

--- a/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/Greeter.java
+++ b/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/Greeter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.verticlefactory;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Thomas Segismont
+ */
+@Component
+public class Greeter {
+
+  public String sayHello(String name) {
+    return "Hello " + name;
+  }
+
+}

--- a/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/GreetingVerticle.java
+++ b/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/GreetingVerticle.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.verticlefactory;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.*;
+
+/**
+ * @author Thomas Segismont
+ */
+@Component
+// Prototype scope is needed as multiple instances of this verticle will be deployed
+@Scope(SCOPE_PROTOTYPE)
+public class GreetingVerticle extends AbstractVerticle {
+  private static final Logger LOG = LoggerFactory.getLogger(GreetingVerticle.class);
+
+  @Autowired
+  Greeter greeter;
+
+  @Override
+  public void start(Future<Void> startFuture) throws Exception {
+    vertx.createHttpServer().requestHandler(request -> {
+      String name = request.getParam("name");
+      LOG.info("Got request for name: " + name);
+      if (name == null) {
+        request.response().setStatusCode(400).end("Missing name");
+      } else {
+        // It's fine to call the greeter from the event loop as it's not blocking
+        request.response().end(greeter.sayHello(name));
+      }
+    }).listen(8080, ar -> {
+      if (ar.succeeded()) {
+        LOG.info("GreetingVerticle started: @" + this.hashCode());
+        startFuture.complete();
+      } else {
+        startFuture.fail(ar.cause());
+      }
+    });
+  }
+}

--- a/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/SpringVerticleFactory.java
+++ b/spring-examples/spring-verticle-factory/src/main/java/io/vertx/examples/spring/verticlefactory/SpringVerticleFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.examples.spring.verticlefactory;
+
+import io.vertx.core.Verticle;
+import io.vertx.core.spi.VerticleFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * A {@link VerticleFactory} backed by Spring's {@link ApplicationContext}. It allows to implement verticles as Spring
+ * beans and thus benefit from dependency injection, ...etc.
+ *
+ * @author Thomas Segismont
+ */
+@Component
+public class SpringVerticleFactory implements VerticleFactory, ApplicationContextAware {
+
+  private ApplicationContext applicationContext;
+
+  @Override
+  public boolean blockingCreate() {
+    // Usually verticle instantiation is fast but since our verticles are Spring Beans,
+    // they might depend on other beans/resources which are slow to build/lookup.
+    return true;
+  }
+
+  @Override
+  public String prefix() {
+    // Just an arbitrary string which must uniquely identify the verticle factory
+    return "myapp";
+  }
+
+  @Override
+  public Verticle createVerticle(String verticleName, ClassLoader classLoader) throws Exception {
+    // Our convention in this example is to give the class name as verticle name
+    String clazz = VerticleFactory.removePrefix(verticleName);
+    return (Verticle) applicationContext.getBean(Class.forName(clazz));
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+  }
+}


### PR DESCRIPTION
It show how you can implement a VerticleFactory delegating bean initialization to the Spring Container.
This is  useful if you want to scale across cpus but still let Spring manage your verticles.