### PR TITLE
trivial: remove redundant `is` from README

### DIFF
--- a/maven-verticles/README.adoc
+++ b/maven-verticles/README.adoc
@@ -1,7 +1,7 @@
 = Vert.x Maven examples
 
 
-This project shows how you can use Apache Maven to package your verticles. Each project is is very similar to the
+This project shows how you can use Apache Maven to package your verticles. Each project is very similar to the
 maven-simplest project but instead of embedding Vert.x it shows an example of writing the code as a verticle.
 
 It covers:


### PR DESCRIPTION
@cescoffier could you please review?