### PR TITLE
Add Java Vert.x event bus SockJS bridge example

### DIFF
--- a/web-examples/src/main/java/io/vertx/example/web/vertxbus/java/Client.java
+++ b/web-examples/src/main/java/io/vertx/example/web/vertxbus/java/Client.java
@@ -1,0 +1,39 @@
+package io.vertx.example.web.vertxbus.java;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.json.JsonObject;
+
+public class Client {
+
+  public static void main(String[] args) {
+    Vertx vertx = Vertx.vertx();
+    HttpClient client = vertx.createHttpClient();
+
+    client.websocket(8080, "localhost", "/eventbus/websocket", ws -> {
+      System.out.println("Connected");
+      sendPing(ws);
+
+      vertx.setPeriodic(5000, id -> {
+        sendPing(ws);
+      });
+
+      // Register
+      JsonObject msg = new JsonObject().put("type", "register").put("address", "feed");
+      ws.writeFrame(io.vertx.core.http.WebSocketFrame.textFrame(msg.encode(), true));
+
+      ws.handler(buff -> {
+        System.out.println(buff);
+      });
+    }, fail -> {
+      System.out.println("Failed: " + fail);
+    });
+  }
+
+  static void sendPing(WebSocket ws) {
+    JsonObject msg = new JsonObject().put("type", "ping");
+    ws.writeFrame(io.vertx.core.http.WebSocketFrame.textFrame(msg.encode(), true));
+  }
+
+}

--- a/web-examples/src/main/java/io/vertx/example/web/vertxbus/java/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/vertxbus/java/Server.java
@@ -1,0 +1,58 @@
+package io.vertx.example.web.vertxbus.java;
+
+import java.text.DateFormat;
+import java.time.Instant;
+import java.util.Date;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.example.util.Runner;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.PermittedOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+
+/**
+ * A {@link io.vertx.core.Verticle} which bridges Java to the @{link EventBus}.
+ */
+public class Server extends AbstractVerticle {
+
+  // Convenience method so you can run it in your IDE
+  public static void main(String[] args) {
+    Runner.runExample(Server.class);
+  }
+
+  @Override
+  public void start() throws Exception {
+
+    Router router = Router.router(vertx);
+
+    // Allow events for the designated addresses in/out of the event bus bridge
+    BridgeOptions opts = new BridgeOptions()
+        .addOutboundPermitted(new PermittedOptions().setAddress("feed"));
+
+    // Create the event bus bridge and add it to the router.
+    SockJSHandler ebHandler = SockJSHandler.create(vertx).bridge(opts);
+    router.route("/eventbus/*").handler(ebHandler);
+
+    // Start the web server and tell it to use the router to handle requests.
+    vertx.createHttpServer().requestHandler(router::accept)
+      .listen(8080, "localhost", ar -> {
+        if (ar.succeeded()) {
+          System.out.printf("Server started on localhost:%s", ar.result().actualPort());
+        } else if (ar.failed()) {
+          System.out.printf("Failed: %s", ar.cause());
+        }
+      });
+
+    EventBus eb = vertx.eventBus();
+
+    vertx.setPeriodic(1000l, t -> {
+      // Create a timestamp string
+      String timestamp = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(Date.from(Instant.now()));
+
+      eb.send("feed", new JsonObject().put("now", timestamp));
+    });
+  }
+}


### PR DESCRIPTION
* Add Vert.x event bus SockJS bridge example where the client is a Java
  client using Vert.x HTTP client API to receive events over websockets.

As promised :)