### PR TITLE
Use counter value as payload body

### DIFF
--- a/grpc-examples/src/main/java/io/vertx/example/grpc/consumer/Client.java
+++ b/grpc-examples/src/main/java/io/vertx/example/grpc/consumer/Client.java
@@ -6,6 +6,7 @@ import io.vertx.example.grpc.ConsumerServiceGrpc;
 import io.vertx.example.grpc.Messages;
 import io.vertx.example.util.Runner;
 import io.vertx.grpc.VertxChannelBuilder;
+import java.nio.charset.Charset;
 
 /*
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
@@ -30,12 +31,16 @@ public class Client extends AbstractVerticle {
     ConsumerServiceGrpc.ConsumerServiceVertxStub stub = ConsumerServiceGrpc.newVertxStub(channel);
 
     // Make a request
-    Messages.StreamingOutputCallRequest request = Messages.StreamingOutputCallRequest.newBuilder().build();
+    Messages.StreamingOutputCallRequest request = Messages
+      .StreamingOutputCallRequest
+      .newBuilder()
+      .build();
 
     // Call the remote service
     stub.streamingOutputCall(request, stream -> {
       stream.handler(response -> {
-        System.out.println(response.getPayload().getType().getNumber());
+        System.out
+          .println(new String(response.getPayload().toByteArray(), Charset.forName("UTF-8")));
       }).endHandler(v -> {
         System.out.println("Response has ended.");
       });

--- a/grpc-examples/src/main/java/io/vertx/example/grpc/consumer/Server.java
+++ b/grpc-examples/src/main/java/io/vertx/example/grpc/consumer/Server.java
@@ -1,12 +1,15 @@
 package io.vertx.example.grpc.consumer;
 
+import com.google.protobuf.ByteString;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.example.grpc.*;
+import io.vertx.example.grpc.ConsumerServiceGrpc;
+import io.vertx.example.grpc.Messages;
+import io.vertx.example.grpc.Messages.PayloadType;
 import io.vertx.example.util.Runner;
 import io.vertx.grpc.GrpcWriteStream;
 import io.vertx.grpc.VertxServer;
 import io.vertx.grpc.VertxServerBuilder;
-
+import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /*
@@ -23,15 +26,24 @@ public class Server extends AbstractVerticle {
   public void start() throws Exception {
 
     // The rcp service
-    ConsumerServiceGrpc.ConsumerServiceVertxImplBase service = new ConsumerServiceGrpc.ConsumerServiceVertxImplBase() {
-      @Override
-      public void streamingOutputCall(Messages.StreamingOutputCallRequest request, GrpcWriteStream<Messages.StreamingOutputCallResponse> response) {
-        final AtomicInteger counter = new AtomicInteger();
-        vertx.setPeriodic(1000L, t -> {
-          response.write(Messages.StreamingOutputCallResponse.newBuilder().setPayload(Messages.Payload.newBuilder().setTypeValue(counter.incrementAndGet())).build());
-        });
-      }
-    };
+    ConsumerServiceGrpc.ConsumerServiceVertxImplBase service =
+      new ConsumerServiceGrpc.ConsumerServiceVertxImplBase() {
+        @Override
+        public void streamingOutputCall(
+          Messages.StreamingOutputCallRequest request,
+          GrpcWriteStream<Messages.StreamingOutputCallResponse> response
+        ) {
+          final AtomicInteger counter = new AtomicInteger();
+          vertx.setPeriodic(1000L, t -> {
+            response.write(Messages.StreamingOutputCallResponse.newBuilder().setPayload(
+              Messages.Payload.newBuilder()
+                .setTypeValue(PayloadType.COMPRESSABLE.getNumber())
+                .setBody(ByteString.copyFrom(
+                  String.valueOf(counter.incrementAndGet()), Charset.forName("UTF-8")))
+            ).build());
+          });
+        }
+      };
 
     // Create the server
     VertxServer rpcServer = VertxServerBuilder


### PR DESCRIPTION
Current example throws an exception after the first two responses due to the value returned from `incrementAndGet` exceeding the enum value range for `PayloadType`. I've updated the example to set the payload type as `COMPRESSABLE` and the payload body as the int value from `incrementAndGet`. It also serves as a simple example of how to convert to and from a `ByteString`.

Hope it's useful.