### PR TITLE
Fix reactjs-server-side-rendering example

### DIFF
--- a/reactjs-server-side-rendering/package.json
+++ b/reactjs-server-side-rendering/package.json
@@ -24,9 +24,9 @@
   "license": "MIT",
 
   "dependencies": {
-      "react": "^15.4.2",
-      "react-dom": "^15.4.2",
-      "react-router": "^3.0.2"
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-router": "^3.0.2"
   },
 
   "devDependencies": {

--- a/reactjs-server-side-rendering/webpack.config.js
+++ b/reactjs-server-side-rendering/webpack.config.js
@@ -147,7 +147,14 @@ var vertxConfig = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
     ]
   }
 };
@@ -164,7 +171,14 @@ var webConfig = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
     ]
   }
 };


### PR DESCRIPTION
`npm start` fails on this example, because of missing presets `es2015` and `react` in the webpack babel-loader config.