### PR TITLE
Kotlin java8 examples

### DIFF
--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    kotlin_version = '1.0.1-2'
+    kotlin_version = '1.1.0'
     vertx_version = '3.4.2'
   }
 
@@ -35,11 +35,18 @@ repositories {
     url "https://oss.sonatype.org/content/repositories/iovertx-3684/"
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
+
 dependencies {
   compile "io.vertx:vertx-core:$vertx_version"
   compile "io.vertx:vertx-web:$vertx_version"
 
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
   compile "org.jetbrains.kotlin:kotlin-runtime:$kotlin_version"
 }
 

--- a/kotlin-example/src/main/java/io/vertx/example/MainVerticle.kt
+++ b/kotlin-example/src/main/java/io/vertx/example/MainVerticle.kt
@@ -11,16 +11,16 @@ import io.vertx.ext.web.RoutingContext
 @Suppress("unused")
 class MainVerticle : AbstractVerticle() {
 
-    override fun start(startFuture: Future<Void>?) {
+    override fun start(startFuture: Future<Void>) {
         val router = createRouter()
 
         vertx.createHttpServer()
                 .requestHandler { router.accept(it) }
                 .listen(config().getInteger("http.port", 8080)) { result ->
                     if (result.succeeded()) {
-                        startFuture?.complete()
+                        startFuture.complete()
                     } else {
-                        startFuture?.fail(result.cause())
+                        startFuture.fail(result.cause())
                     }
                 }
     }


### PR DESCRIPTION
Configure kotlin examples to target java8. Also `startFuture` should never be null.