### PR TITLE
Changing ProxyHelper class methods in vert.x3.5.0

### DIFF
--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRestApi.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/BookRestApi.java
@@ -23,7 +23,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.StaticHandler;
-import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -45,7 +45,7 @@ public class BookRestApi extends AbstractVerticle {
 
   @Override
   public void start(Future<Void> startFuture) throws Exception {
-    bookAsyncService = ProxyHelper.createProxy(BookAsyncService.class, vertx, BookAsyncService.ADDRESS);
+    bookAsyncService = new ServiceProxyBuilder(vertx).setAddress(BookAsyncService.ADDRESS).build(BookAsyncService.class);
 
     Router router = Router.router(vertx);
 

--- a/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringWorker.java
+++ b/spring-examples/spring-worker-example/src/main/java/io/vertx/example/spring/worker/SpringWorker.java
@@ -18,7 +18,7 @@ package io.vertx.example.spring.worker;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
-import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +45,7 @@ public class SpringWorker extends AbstractVerticle {
 
   @Override
   public void start(Future<Void> startFuture) throws Exception {
-    ProxyHelper.registerService(BookAsyncService.class, vertx, bookAsyncService, BookAsyncService.ADDRESS).completionHandler(ar -> {
+    new ServiceBinder(vertx).setAddress(BookAsyncService.ADDRESS).register(BookAsyncService.class, bookAsyncService).completionHandler(ar ->{
       if (ar.succeeded()) {
         LOG.info("SpringWorker started");
         startFuture.complete();


### PR DESCRIPTION
First of all, thanks for providing an example of how you can use Vert.x worker in Spring.
Recently, I found deprecated message in IDE(Eclipse) vert.x 3.5.0 env,   "Vert.x ProxyHelper class is deprecated."
I've changed two parts in vertx-examples/spring-worker-example on using ServiceProxyBuilder and ServiceBinder class. 
This fixing source I changed based on the URL below.

[1]. http://vertx.io/docs/apidocs/index.html?io/vertx/serviceproxy/ProxyHelper.html
[2]. http://vertx.io/docs/vertx-service-proxy/java/