### PR TITLE
fixed nopreflight.html, improved Server.java and preflight.html implementation

### DIFF
--- a/web-examples/src/main/java/io/vertx/example/web/cors/.editorconfig
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true

--- a/web-examples/src/main/java/io/vertx/example/web/cors/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/Server.java
@@ -3,65 +3,84 @@ package io.vertx.example.web.cors;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.example.util.Runner;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.handler.StaticHandler;
 
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 /*
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ * reviewed by: Giacomo Venturini mail: giacomo.venturini3@gmail.com"
  */
 public class Server extends AbstractVerticle {
 
-  // Convenience method so you can run it in your IDE
-  public static void main(String[] args) {
-    Runner.runExample(Server.class);
-  }
+    // Convenience method so you can run it in your IDE
+    public static void main(String[] args) {
+        Runner.runExample(Server.class);
+    }
 
-  @Override
-  public void start() throws Exception {
+    @Override
+    public void start() throws Exception {
 
-    Router router = Router.router(vertx);
+        Router router = Router.router(vertx);
 
-    router.route().handler(CorsHandler.create("*")
-      .allowedMethod(HttpMethod.GET)
-      .allowedMethod(HttpMethod.POST)
-      .allowedMethod(HttpMethod.OPTIONS)
-      .allowedHeader("X-PINGARUNER")
-      .allowedHeader("Content-Type"));
+        Set<String> allowedHeaders = new HashSet<>();
+        allowedHeaders.add("x-requested-with");
+        allowedHeaders.add("Access-Control-Allow-Origin");
+        allowedHeaders.add("origin");
+        allowedHeaders.add("Content-Type");
+        allowedHeaders.add("accept");
+        allowedHeaders.add("X-PINGARUNER");
 
-    router.get("/access-control-with-get").handler(ctx -> {
+        Set<HttpMethod> allowedMethods = new HashSet<>();
+        allowedMethods.add(HttpMethod.GET);
+        allowedMethods.add(HttpMethod.POST);
+        allowedMethods.add(HttpMethod.OPTIONS);
+        /* 
+            these methods aren't necessary for this sample, 
+            but you may need them for your projects
+        */
+        allowedMethods.add(HttpMethod.DELETE);
+        allowedMethods.add(HttpMethod.PATCH);
+        allowedMethods.add(HttpMethod.PUT);
+        
 
-      ctx.response().setChunked(true);
+        router.route().handler(CorsHandler.create("*")
+            .allowedHeaders(allowedHeaders)
+            .allowedMethods(allowedMethods));
 
-      MultiMap headers = ctx.request().headers();
-      for (String key : headers.names()) {
-        ctx.response().write(key);
-        ctx.response().write(headers.get(key));
-        ctx.response().write("\n");
-      }
+        router.get("/access-control-with-get").handler(ctx -> {
+            HttpServerResponse httpServerResponse = ctx.response();
+            httpServerResponse.setChunked(true);
+            MultiMap headers = ctx.request().headers();
+            for (String key : headers.names()){
+                httpServerResponse.write(key + ": ");
+                httpServerResponse.write(headers.get(key));
+                httpServerResponse.write("<br>");
+            }
+            httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
+        });
 
-      ctx.response().end();
-    });
+        router.post("/access-control-with-post-preflight").handler(ctx -> {
+            HttpServerResponse httpServerResponse = ctx.response();
+            httpServerResponse.setChunked(true);
+            MultiMap headers = ctx.request().headers();
+            for (String key : headers.names()) {
+              httpServerResponse.write(key + ": ");
+              httpServerResponse.write(headers.get(key));
+              httpServerResponse.write("<br>");
+            }
+            httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
+        });
 
-    router.post("/access-control-with-post-preflight").handler(ctx -> {
-      ctx.response().setChunked(true);
+        // Serve the static resources
+        router.route().handler(StaticHandler.create());
 
-      MultiMap headers = ctx.request().headers();
-      for (String key : headers.names()) {
-        ctx.response().write(key);
-        ctx.response().write(headers.get(key));
-        ctx.response().write("\n");
-      }
-
-      ctx.response().end();
-    });
-
-    // Serve the static resources
-    router.route().handler(StaticHandler.create());
-
-    vertx.createHttpServer().requestHandler(router::accept).listen(8080);
-  }
+        vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+    }
 }

--- a/web-examples/src/main/java/io/vertx/example/web/cors/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/Server.java
@@ -19,68 +19,65 @@ import java.util.Set;
  */
 public class Server extends AbstractVerticle {
 
-    // Convenience method so you can run it in your IDE
-    public static void main(String[] args) {
-        Runner.runExample(Server.class);
-    }
+  // Convenience method so you can run it in your IDE
+  public static void main(String[] args) {
+    Runner.runExample(Server.class);
+  }
 
-    @Override
-    public void start() throws Exception {
+  @Override
+  public void start() throws Exception {
 
-        Router router = Router.router(vertx);
+    Router router = Router.router(vertx);
 
-        Set<String> allowedHeaders = new HashSet<>();
-        allowedHeaders.add("x-requested-with");
-        allowedHeaders.add("Access-Control-Allow-Origin");
-        allowedHeaders.add("origin");
-        allowedHeaders.add("Content-Type");
-        allowedHeaders.add("accept");
-        allowedHeaders.add("X-PINGARUNER");
+    Set<String> allowedHeaders = new HashSet<>();
+    allowedHeaders.add("x-requested-with");
+    allowedHeaders.add("Access-Control-Allow-Origin");
+    allowedHeaders.add("origin");
+    allowedHeaders.add("Content-Type");
+    allowedHeaders.add("accept");
+    allowedHeaders.add("X-PINGARUNER");
 
-        Set<HttpMethod> allowedMethods = new HashSet<>();
-        allowedMethods.add(HttpMethod.GET);
-        allowedMethods.add(HttpMethod.POST);
-        allowedMethods.add(HttpMethod.OPTIONS);
-        /* 
-            these methods aren't necessary for this sample, 
-            but you may need them for your projects
-        */
-        allowedMethods.add(HttpMethod.DELETE);
-        allowedMethods.add(HttpMethod.PATCH);
-        allowedMethods.add(HttpMethod.PUT);
-        
+    Set<HttpMethod> allowedMethods = new HashSet<>();
+    allowedMethods.add(HttpMethod.GET);
+    allowedMethods.add(HttpMethod.POST);
+    allowedMethods.add(HttpMethod.OPTIONS);
+    /*
+     * these methods aren't necessary for this sample, 
+     * but you may need them for your projects
+     */
+    allowedMethods.add(HttpMethod.DELETE);
+    allowedMethods.add(HttpMethod.PATCH);
+    allowedMethods.add(HttpMethod.PUT);
 
-        router.route().handler(CorsHandler.create("*")
-            .allowedHeaders(allowedHeaders)
-            .allowedMethods(allowedMethods));
+    router.route().handler(CorsHandler.create("*").allowedHeaders(allowedHeaders).allowedMethods(allowedMethods));
 
-        router.get("/access-control-with-get").handler(ctx -> {
-            HttpServerResponse httpServerResponse = ctx.response();
-            httpServerResponse.setChunked(true);
-            MultiMap headers = ctx.request().headers();
-            for (String key : headers.names()){
-                httpServerResponse.write(key + ": ");
-                httpServerResponse.write(headers.get(key));
-                httpServerResponse.write("<br>");
-            }
-            httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
-        });
+    router.get("/access-control-with-get").handler(ctx -> {
+      HttpServerResponse httpServerResponse = ctx.response();
+      httpServerResponse.setChunked(true);
+      MultiMap headers = ctx.request().headers();
+      for (String key : headers.names()) {
+        httpServerResponse.write(key + ": ");
+        httpServerResponse.write(headers.get(key));
+        httpServerResponse.write("<br>");
+      }
+      httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
+    });
 
-        router.post("/access-control-with-post-preflight").handler(ctx -> {
-            HttpServerResponse httpServerResponse = ctx.response();
-            httpServerResponse.setChunked(true);
-            MultiMap headers = ctx.request().headers();
-            for (String key : headers.names()) {
-              httpServerResponse.write(key + ": ");
-              httpServerResponse.write(headers.get(key));
-              httpServerResponse.write("<br>");
-            }
-            httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
-        });
+    router.post("/access-control-with-post-preflight").handler(ctx -> {
+      HttpServerResponse httpServerResponse = ctx.response();
+      httpServerResponse.setChunked(true);
+      MultiMap headers = ctx.request().headers();
+      for (String key : headers.names()) {
+        httpServerResponse.write(key + ": ");
+        httpServerResponse.write(headers.get(key));
+        httpServerResponse.write("<br>");
+      }
+      httpServerResponse.putHeader("Content-Type", "application/text").end("Success");
+    });
 
-        // Serve the static resources
-        router.route().handler(StaticHandler.create());
+    // Serve the static resources
+    router.route().handler(StaticHandler.create());
 
-        vertx.createHttpServer().requestHandler(router::accept).listen(8080);
-    }
+    vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+  }
 }

--- a/web-examples/src/main/java/io/vertx/example/web/cors/webroot/nopreflight.html
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/webroot/nopreflight.html
@@ -4,50 +4,22 @@
 <head>
     <title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
     <script type="text/javascript">
-        //<![CDATA[
-
-        var invocation = new XMLHttpRequest();
         var url = 'http://localhost:8080/access-control-with-get/';
-        var invocationHistoryText;
 
-        function callOtherDomain(){
-            if(invocation)
-            {
-                invocation.open('GET', url, true);
-                invocation.onreadystatechange = handler;
-                invocation.send();
-            }
-            else
-            {
-                invocationHistoryText = "No Invocation TookPlace At All";
-                var textNode = document.createTextNode(invocationHistoryText);
-                var textDiv = document.getElementById("textDiv");
-                textDiv.appendChild(textNode);
-            }
-
-        }
-        function handler(evtXHR)
-        {
-            if (invocation.readyState == 4)
-            {
-                if (invocation.status == 200)
-                {
-                    var response = invocation.responseXML;
-                    var invocationHistory = response.getElementsByTagName('invocationHistory').item(0).firstChild.data;
-                    invocationHistoryText = document.createTextNode(invocationHistory);
-                    var textDiv = document.getElementById("textDiv");
-                    textDiv.appendChild(invocationHistoryText);
-
+        function callOtherDomain() {
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState == 4 && this.status == 200) {
+                    var e = document.createElement('p');
+                    e.innerHTML = xhttp.responseText;
+                    document.getElementById("textDiv").appendChild(e);
+                } else {
+                    console.log("XMLHttpRequest readyState:" + this.readyState + " status: " + this.status);
                 }
-                else
-                    alert("Invocation Errors Occured");
-            }
-            else
-                dump("currently the application is at" + invocation.readyState);
+            };
+            xhttp.open("GET", url, true);
+            xhttp.send();
         }
-        //]]>
-
-
     </script>
 </head>
 <body>
@@ -57,7 +29,7 @@
     </p>
 </form>
 <p id="intro">
-    This page basically makes invocations to another domain using cross-site XMLHttpRequest mitigated by Access Control.  This is the simple scenario that is <em>NOT</em> preflighted, and the invocation to a resource on another domain takes place using a simple HTTP GET.
+    This page basically makes invocations to another domain using cross-site XMLHttpRequest mitigated by Access Control. This is the simple scenario that is <em>NOT</em> preflighted, and the invocation to a resource on another domain takes place using a simple HTTP GET.
 </p>
 <div id="textDiv">
     This XHTML document invokes another resource using cross-site XHR.

--- a/web-examples/src/main/java/io/vertx/example/web/cors/webroot/nopreflight.html
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/webroot/nopreflight.html
@@ -2,37 +2,41 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
-    <script type="text/javascript">
-        var url = 'http://localhost:8080/access-control-with-get/';
+<title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
+<script type="text/javascript">
+	var url = 'http://localhost:8080/access-control-with-get/';
 
-        function callOtherDomain() {
-            var xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = function() {
-                if (this.readyState == 4 && this.status == 200) {
-                    var e = document.createElement('p');
-                    e.innerHTML = xhttp.responseText;
-                    document.getElementById("textDiv").appendChild(e);
-                } else {
-                    console.log("XMLHttpRequest readyState:" + this.readyState + " status: " + this.status);
-                }
-            };
-            xhttp.open("GET", url, true);
-            xhttp.send();
-        }
-    </script>
+	function callOtherDomain() {
+		var xhttp = new XMLHttpRequest();
+		xhttp.onreadystatechange = function() {
+			if (this.readyState == 4 && this.status == 200) {
+				var e = document.createElement('p');
+				e.innerHTML = xhttp.responseText;
+				document.getElementById("textDiv").appendChild(e);
+			} else {
+				console.log("XMLHttpRequest readyState:" + this.readyState
+						+ " status: " + this.status);
+			}
+		};
+		xhttp.open("GET", url, true);
+		xhttp.send();
+	}
+</script>
 </head>
 <body>
-<form id="controlsToInvoke" action="">
-    <p>
-        <input type="button" value="Click to Invoke Another Site" onclick="callOtherDomain()" />
-    </p>
-</form>
-<p id="intro">
-    This page basically makes invocations to another domain using cross-site XMLHttpRequest mitigated by Access Control. This is the simple scenario that is <em>NOT</em> preflighted, and the invocation to a resource on another domain takes place using a simple HTTP GET.
-</p>
-<div id="textDiv">
-    This XHTML document invokes another resource using cross-site XHR.
-</div>
+	<form id="controlsToInvoke" action="">
+		<p>
+			<input type="button" value="Click to Invoke Another Site"
+				onclick="callOtherDomain()" />
+		</p>
+	</form>
+	<p id="intro">
+		This page basically makes invocations to another domain using
+		cross-site XMLHttpRequest mitigated by Access Control. This is the
+		simple scenario that is <em>NOT</em> preflighted, and the invocation
+		to a resource on another domain takes place using a simple HTTP GET.
+	</p>
+	<div id="textDiv">This XHTML document invokes another resource
+		using cross-site XHR.</div>
 </body>
 </html>

--- a/web-examples/src/main/java/io/vertx/example/web/cors/webroot/preflight.html
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/webroot/preflight.html
@@ -4,58 +4,24 @@
 <head>
     <title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
     <script type="text/javascript">
-        //<![CDATA[
-
-        var invocation = new XMLHttpRequest();
         var url = 'http://localhost:8080/access-control-with-post-preflight/';
-        var invocationHistoryText;
-        var body = '<?xml version="1.0"?><person><name>Arun</name></person>';
 
-        function callOtherDomain(){
-            if(invocation)
-            {
-                invocation.open('POST', url, true);
-                invocation.setRequestHeader('X-PINGARUNER', 'pingpong');
-                invocation.setRequestHeader('Content-Type',
-                        'application/xml');
-                invocation.onreadystatechange = handler;
-                invocation.send(body);
-            }
-            else
-            {
-                invocationHistoryText = "No Invocation TookPlace At All";
-                var textNode = document.createTextNode(invocationHistoryText);
-                var textDiv = document.getElementById("textDiv");
-                textDiv.appendChild(textNode);
-            }
-
-        }
-        function handler(evtXHR)
-        {
-            if (invocation.readyState == 4)
-            {
-                if (invocation.status == 200)
-                {
-                    var response = invocation.responseText;
-                    //var invocationHistory = response.getElementsByTagName('invocationHistory').item(0).firstChild.data;
-                    invocationHistoryText = document.createTextNode(response);
-                    var textDiv = document.getElementById("textDiv");
-                    textDiv.appendChild(invocationHistoryText);
-
+        function callOtherDomain() {
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState == 4 && this.status == 200) {
+                    var e = document.createElement('p');
+                    e.innerHTML = xhttp.responseText;
+                    document.getElementById("textDiv").appendChild(e);
+                } else {
+                    console.log("XMLHttpRequest readyState:" + this.readyState + " status: " + this.status);
                 }
-                else
-                {
-                    alert("Invocation Errors Occured " + invocation.readyState + " and the status is " + invocation.status);
-                }
-            }
-            else
-            {
-                dump("currently the application is at" + invocation.readyState);
-            }
+            };
+            xhttp.open("POST", url, true);
+            xhttp.setRequestHeader('X-PINGARUNER', 'pingpong');
+            xhttp.setRequestHeader('Content-Type', 'application/text');
+            xhttp.send();
         }
-        //]]>
-
-
     </script>
 </head>
 <body>
@@ -65,7 +31,7 @@
     </p>
 </form>
 <p id="intro">
-    This page POSTs XML data to another domain using cross-site XMLHttpRequest mitigated by Access Control.  This is the preflight scenario and the invocation to a resource on another domain takes place using first an OPTIONS request, then an actual POST request.
+    This page POSTs XML data to another domain using cross-site XMLHttpRequest mitigated by Access Control. This is the preflight scenario and the invocation to a resource on another domain takes place using first an OPTIONS request, then an actual POST request.
 </p>
 <div id="textDiv">
     This XHTML document POSTs to another resource using cross-site XHR.  If you get a response back, the content of that response should reflect what you POSTed.

--- a/web-examples/src/main/java/io/vertx/example/web/cors/webroot/preflight.html
+++ b/web-examples/src/main/java/io/vertx/example/web/cors/webroot/preflight.html
@@ -2,39 +2,43 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
-    <script type="text/javascript">
-        var url = 'http://localhost:8080/access-control-with-post-preflight/';
+<title>Simple use of Cross-Site XMLHttpRequest (Using Access Control)</title>
+<script type="text/javascript">
+	var url = 'http://localhost:8080/access-control-with-post-preflight/';
 
-        function callOtherDomain() {
-            var xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = function() {
-                if (this.readyState == 4 && this.status == 200) {
-                    var e = document.createElement('p');
-                    e.innerHTML = xhttp.responseText;
-                    document.getElementById("textDiv").appendChild(e);
-                } else {
-                    console.log("XMLHttpRequest readyState:" + this.readyState + " status: " + this.status);
-                }
-            };
-            xhttp.open("POST", url, true);
-            xhttp.setRequestHeader('X-PINGARUNER', 'pingpong');
-            xhttp.setRequestHeader('Content-Type', 'application/text');
-            xhttp.send();
-        }
-    </script>
+	function callOtherDomain() {
+		var xhttp = new XMLHttpRequest();
+		xhttp.onreadystatechange = function() {
+			if (this.readyState == 4 && this.status == 200) {
+				var e = document.createElement('p');
+				e.innerHTML = xhttp.responseText;
+				document.getElementById("textDiv").appendChild(e);
+			} else {
+				console.log("XMLHttpRequest readyState:" + this.readyState
+						+ " status: " + this.status);
+			}
+		};
+		xhttp.open("POST", url, true);
+		xhttp.setRequestHeader('X-PINGARUNER', 'pingpong');
+		xhttp.setRequestHeader('Content-Type', 'application/text');
+		xhttp.send();
+	}
+</script>
 </head>
 <body>
-<form id="controlsToInvoke" action="">
-    <p>
-        <input type="button" value="Click to Invoke Another Site" onclick="callOtherDomain()" />
-    </p>
-</form>
-<p id="intro">
-    This page POSTs XML data to another domain using cross-site XMLHttpRequest mitigated by Access Control. This is the preflight scenario and the invocation to a resource on another domain takes place using first an OPTIONS request, then an actual POST request.
-</p>
-<div id="textDiv">
-    This XHTML document POSTs to another resource using cross-site XHR.  If you get a response back, the content of that response should reflect what you POSTed.
-</div>
+	<form id="controlsToInvoke" action="">
+		<p>
+			<input type="button" value="Click to Invoke Another Site"
+				onclick="callOtherDomain()" />
+		</p>
+	</form>
+	<p id="intro">This page POSTs XML data to another domain using
+		cross-site XMLHttpRequest mitigated by Access Control. This is the
+		preflight scenario and the invocation to a resource on another domain
+		takes place using first an OPTIONS request, then an actual POST
+		request.</p>
+	<div id="textDiv">This XHTML document POSTs to another resource
+		using cross-site XHR. If you get a response back, the content of that
+		response should reflect what you POSTed.</div>
 </body>
 </html>


### PR DESCRIPTION
Under the web-examples directory I noticed that the CORS nopreflight example was not working.  I fixed it changing the function that makes the asynchronous request following the style guide proposed at w3schools.com. I also have changed the preflight implementation to better display the response datas (they were displayed as a single line of text). I also changed the Server.java to better clarify how to correctly configure headers and HTTP methods in Vert.x