### PR TITLE
An example for using as starting point of an open discussion about the design

### DIFF
--- a/web-client-examples/src/main/java/io/vertx/example/webclient/response/clienterrors/Client.java
+++ b/web-client-examples/src/main/java/io/vertx/example/webclient/response/clienterrors/Client.java
@@ -1,0 +1,40 @@
+package io.vertx.example.webclient.response.clienterrors;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.json.JsonObject;
+import io.vertx.example.util.Runner;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
+
+public class Client extends AbstractVerticle {
+
+  // Convenience method so you can run it in your IDE
+  public static void main(String[] args) {
+    Runner.runExample(Client.class);
+  }
+
+  public static class User {
+    public String login;
+    public Long id;
+  }
+
+  @Override
+  public void start() throws Exception {
+
+    WebClient client = WebClient.create(vertx);
+
+    client.get(8080, "localhost", "/")
+      .as(BodyCodec.json(User.class))
+      .send(ar -> {
+        if (ar.succeeded()) {
+          HttpResponse<User> response = ar.result();
+          User user = response.body();
+          System.out.println("Got HTTP response body");
+          System.out.println(user.toString());
+        } else {
+          ar.cause().printStackTrace();
+        }
+      });
+  }
+}

--- a/web-client-examples/src/main/java/io/vertx/example/webclient/response/clienterrors/Server.java
+++ b/web-client-examples/src/main/java/io/vertx/example/webclient/response/clienterrors/Server.java
@@ -1,0 +1,36 @@
+package io.vertx.example.webclient.response.clienterrors;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.json.JsonObject;
+import io.vertx.example.util.Runner;
+
+public class Server extends AbstractVerticle {
+
+  // Convenience method so you can run it in your IDE
+  public static void main(String[] args) {
+    Runner.runExample(Server.class);
+  }
+
+  @Override
+  public void start() throws Exception {
+
+    vertx.createHttpServer().requestHandler(req -> {
+      req.response()
+        .putHeader("Content/type", "application/json")
+        .setStatusCode(404)
+        .end(new JsonObject()
+          .put("message", "Not Found")
+          .put("documentation_url", "https://developer.github.com/v3/users/#get-a-single-user")
+          .encode()
+        );
+
+    }).listen(8080, listenResult -> {
+      if (listenResult.failed()) {
+        System.out.println("Could not start HTTP server");
+        listenResult.cause().printStackTrace();
+      } else {
+        System.out.println("Server started");
+      }
+    });
+  }
+}


### PR DESCRIPTION
This PR only tries to be a starting point for a design discussion about Vertx Web Client.

Over the last days I was talking to @cescoffier about this subject in order to make sure that I was understanding the proposed design.

The result of this example is:

```java
io.vertx.core.json.DecodeException: Failed to decode: Unrecognized field "message" (class io.vertx.example.webclient.response.clienterrors.Client$User), not marked as ignorable (2 known properties: "login", "id"])
 at [Source: (String)"{"message":"Not Found","documentation_url":"https://developer.github.com/v3/users/#get-a-single-user"}"; line: 1, column: 13] (through reference chain: io.vertx.example.webclient.response.clienterrors.Client$User["message"])
	at io.vertx.core.json.Json.decodeValue(Json.java:124)
	at io.vertx.ext.web.codec.impl.BodyCodecImpl.lambda$jsonDecoder$4(BodyCodecImpl.java:56)
	at io.vertx.ext.web.codec.impl.BodyCodecImpl$1.end(BodyCodecImpl.java:101)
	at io.vertx.ext.web.client.impl.HttpContext.lambda$null$4(HttpContext.java:144)
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleEnd(HttpClientResponseImpl.java:261)
	at io.vertx.core.http.impl.ClientConnection.handleResponseEnd(ClientConnection.java:358)
	at io.vertx.core.http.impl.ClientHandler.handleMessage(ClientHandler.java:100)
	at io.vertx.core.http.impl.ClientHandler.handleMessage(ClientHandler.java:36)
	at io.vertx.core.net.impl.VertxHandler.lambda$channelRead$1(VertxHandler.java:150)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:342)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:200)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:148)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
```
The client is waiting for something like this:

```
{
  "login": "recena",
  "id": 1021745,
}
```

But we have received a `404` (very usual on a Rest API Client) and a JSON with extra info.

It seems we are not able to manage customized `HttpResponse<T>`. Why not using this?

```java
class GitHubResponseImpl<T> implements HttpResponse<T> {
    private final HttpClientResponse resp;
    private Buffer buff;
    private T body;
    private GitHubClientError error;
}
```

And do this:

```java
if (ar.succeeded()) {
    HttpResponse<User> response = ar.result();
    if (response.body() != null) {
        LOGGER.debug("Received response with status: " + response.statusMessage() + " (" + response.statusCode() + ")");
        User user = response.body();
    } else {
        response.getError()....
    }
}
```

Probably, I'm doing something wrong but I'm able to get what I need.

