### PR TITLE
initialize vertx instance

### DIFF
--- a/web-examples/src/main/kotlin/io/vertx/example/web/helloworld/Server.kt
+++ b/web-examples/src/main/kotlin/io/vertx/example/web/helloworld/Server.kt
@@ -4,6 +4,8 @@ import io.vertx.ext.web.Router
 
 class Server : io.vertx.core.AbstractVerticle()  {
   override fun start() {
+    
+    vertx = Vertx.vertx()
 
     var router = Router.router(vertx)
 


### PR DESCRIPTION
As it stands, calling start() on a fresh instance of the Server() throws a null pointer exception because vertx is not initialized. This commit ensures that it is.