### PR TITLE
Improving vertx-heroku example

### DIFF
--- a/heroku-example/pom.xml
+++ b/heroku-example/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>vertx-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -74,7 +79,7 @@
       <plugin>
         <groupId>com.heroku.sdk</groupId>
         <artifactId>heroku-maven-plugin</artifactId>
-        <version>0.5.6</version>
+        <version>2.0.7</version>
         <configuration>
           <processTypes>
             <web>java $JAVA_OPTS -Dhttp.port=$PORT -jar target/heroku-example-${project.version}-fat.jar</web>

--- a/heroku-example/src/main/java/io/vertx/example/HelloWorldVerticle.java
+++ b/heroku-example/src/main/java/io/vertx/example/HelloWorldVerticle.java
@@ -1,15 +1,63 @@
 package io.vertx.example;
 
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Vertx;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 public class HelloWorldVerticle extends AbstractVerticle {
 
+  private ConfigRetriever configRetriever;
+  private JsonObject config;
+
   @Override
-  public void start() throws Exception {
-    vertx.createHttpServer().requestHandler(req -> req.response().end("Hello World!"))
-    .listen(
-        Integer.getInteger("http.port"), System.getProperty("http.address", "0.0.0.0"));
+  public void start(Future<Void> startFuture) throws Exception {
+    retrieveConfig().setHandler(ar -> {
+      if (ar.succeeded()) {
+        vertx.createHttpServer()
+          .requestHandler(req -> req.response().end("Hello World!"))
+          .listen(config.getInteger("http.port"), config.getString("http.address", "0.0.0.0"));
+        startFuture.complete();
+      } else {
+        startFuture.fail(ar.cause());
+      }
+    });
+  }
+
+  @Override
+  public void stop() throws Exception {
+    configRetriever.close();
+    super.stop();
+  }
+
+  private Future<Void> retrieveConfig() {
+    final Future<Void> future = Future.future();
+
+    // Option for reading the Config Vars which are defined in the settings of the application on Heroku
+    final ConfigStoreOptions configStoreEnvOptions = new ConfigStoreOptions()
+      .setType("env")
+      .setOptional(true);
+
+    final ConfigStoreOptions configStoreSysOptions = new ConfigStoreOptions()
+      .setType("sys")
+      .setOptional(true);
+
+    final ConfigRetrieverOptions configRetrieverOptions = new ConfigRetrieverOptions()
+      .addStore(configStoreEnvOptions)
+      .addStore(configStoreSysOptions);
+
+    configRetriever = ConfigRetriever.create(vertx, configRetrieverOptions);
+    configRetriever.getConfig(ar -> {
+      if (ar.succeeded()) {
+        config = ar.result();
+        future.complete();
+      } else {
+        future.fail(ar.cause());
+      }
+    });
+
+    return future;
   }
 }
-


### PR DESCRIPTION
The current vertx-heroku example is not compiling with Java 10. sun.misc.BASE64Encoder is missing updating the heroku-maven-plugin to the current version fixes that issue. I also would like to propose to use the vertx config retriever for fetching the system properties and the config vars defined in heroku's application settings.