### PR TITLE
feat: Add Eclipse JKube example following current DMP + FMP example

### DIFF
--- a/docker-examples/vertx-docker-example-jkube/README.md
+++ b/docker-examples/vertx-docker-example-jkube/README.md
@@ -1,0 +1,68 @@
+# Vert.x Docker Example for Fabric8
+
+This project builds a docker image launching a very simple Vert.x verticle that you can deploy to
+[Kubernetes](http://kubernetes.io/) using the [Eclipse JKube](https://www.eclipse.org/jkube)
+[Kubernetes-maven-plugin](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin).
+
+## Build the image
+
+To [build](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#jkube:build) the docker image, just launch:
+
+```shell script
+$ mvn clean package k8s:build
+```
+
+Notice that you need to have docker installed on your machine. If you are planning to deploy the application into a
+cluster you'll either have to [push](#Pushing-the-image) your image to a shared registry or build the image using the
+cluster's Docker daemon.
+```shell script
+# Use Minikube Docker daemon to build the image
+$ eval $(minikube docker-env)
+```
+## Deployment on Kubernetes
+
+In order to deploy the application into Kubernetes you'll need to build
+[resource](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#jkube:resource) manifests and
+[apply](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#jkube:apply) them to the cluster.
+
+The following Kubernetes-Maven-Plugin goals will do that for you:
+
+```shell script
+$ mvn k8s:resource k8s:apply
+```
+
+## Pushing the image
+
+If you want to deploy the image into a remote cluster (not Minikube), you'll need to
+[push](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#jkube:push) the image to a Docker registry accessible
+from the cluster.
+
+You'll probably need to change the image name so that you can push to your specific organization, you can accomplish that
+by using the `jkube.generator.name` JKube Maven property. You will also need to perform a `docker login` if your registry
+requires authentication.
+
+```shell script
+$ mvn -Djkube.generator.name=${organization}/${name} k8s:build k8s:push k8s:resource k8s:apply
+```
+
+## Trying it out
+
+You can check out the newly created pod, deployment and service by running:
+```shell script
+$ kubectl get svc,pod,deploy
+```
+
+If you are using Minikube, you can perform a request to the deployed Pod container by running:
+```shell script
+$  curl $(minikube ip):$(kubectl get svc vertx-docker-example-jkube -n default -o jsonpath='{.spec.ports[].nodePort}')
+```
+
+You can retrieve the application [log](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#jkube:log) by running:
+```shell script
+$ mvn k8s:log
+```
+
+When you are finished you can clean the generated resources and remove the deployment from your cluster by running:
+```shell script
+$ mvn k8s:undeploy
+```

--- a/docker-examples/vertx-docker-example-jkube/pom.xml
+++ b/docker-examples/vertx-docker-example-jkube/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-docker-example-jkube</artifactId>
+  <version>3.9.0</version>
+
+  <name>Sample Docker Image and Deployment using JKube</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <vertx-maven-plugin.version>1.0.18</vertx-maven-plugin.version>
+    <jkube.version>1.0.0-rc-1</jkube.version>
+    <vertx.verticle>io.vertx.example.HelloWorldVerticle</vertx.verticle>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.reactiverse</groupId>
+        <artifactId>vertx-maven-plugin</artifactId>
+        <version>${vertx-maven-plugin.version}</version>
+        <configuration>
+          <redeploy>true</redeploy>
+        </configuration>
+        <executions>
+          <execution>
+            <id>vmp</id>
+            <phase>package</phase>
+            <goals>
+              <goal>initialize</goal>
+              <goal>package</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>${jkube.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>staging</id>
+      <repositories>
+        <repository>
+          <id>staging</id>
+          <url>https://oss.sonatype.org/content/repositories/iovertx-3868/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</project>

--- a/docker-examples/vertx-docker-example-jkube/src/main/java/io/vertx/example/HelloWorldVerticle.java
+++ b/docker-examples/vertx-docker-example-jkube/src/main/java/io/vertx/example/HelloWorldVerticle.java
@@ -1,0 +1,12 @@
+package io.vertx.example;
+
+import io.vertx.core.AbstractVerticle;
+
+public class HelloWorldVerticle extends AbstractVerticle {
+
+    @Override
+    public void start() {
+        vertx.createHttpServer().requestHandler(req -> req.response().end("Hello World!")).listen(8080);
+    }
+
+}


### PR DESCRIPTION
## Motivation:

[Fabric8 Maven Plugin](https://github.com/fabric8io/fabric8-maven-plugin) (FMP) will be deprecated soon, [Eclipse JKube](https://github.com/eclipse/jkube) should be used instead.

Eclipse JKube 1.0.0-rc-1 was recently released, and as part of the core maintainer team, we need feedback from the community to see if current projects depending on FMP can be easily upgraded to use JKube. As part of the strategy to seek this feedback we are creating PRs on those repositories which we know are currently using FMP. In this case, our intention is to keep the examples up to date providing updates whenever we release new features or major releases affecting Vert.x.

This example is just a port of the existing [vertx-docker-example-fabric8](https://github.com/vert-x3/vertx-examples/tree/3.x/docker-examples/vertx-docker-example-fabric8) example but using Eclipse JKube instead.

