### PR TITLE
http2-showcase - fix compile error

### DIFF
--- a/http2-showcase/src/main/java/io/vertx/examples/http2/Http2ServerVerticle.java
+++ b/http2-showcase/src/main/java/io/vertx/examples/http2/Http2ServerVerticle.java
@@ -9,7 +9,7 @@ import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.handler.TemplateHandler;
-import io.vertx.ext.web.templ.HandlebarsTemplateEngine;
+import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -75,7 +75,7 @@ public class Http2ServerVerticle extends AbstractVerticle {
 
     private Router createRouter(String redirectURL) {
         Router router = Router.router(vertx);
-        HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create();
+        HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create(vertx);
         engine.setMaxCacheSize(0);
         router.get("/*").handler(rc -> {
           int queryLatency = DEFAULT_LATENCY;


### PR DESCRIPTION
Fixed this error: actual and formal argument lists differ in length

> Task :compileJava
/Users/dennch3/temp/vertx-examples/http2-showcase/src/main/java/io/vertx/examples/http2/Http2ServerVerticle.java:78: error: method create in interface HandlebarsTemplateEngine cannot be applied to given types;
        HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create();
                                                                  ^
  required: Vertx
  found: no arguments
  reason: actual and formal argument lists differ in length