### PR TITLE
Added Swagger-Core to generate the OpenAPI file on the fly

### DIFF
--- a/resteasy-examples/README.adoc
+++ b/resteasy-examples/README.adoc
@@ -47,3 +47,19 @@ Add a product:: PUT /products/<product_id>
 
 Run the server either in your IDE or on the command line, then open your browser and hit
 link:http://localhost:8080/
+
+=== OpenAPI Schema Generation
+
+Generate and get the openapi specification at:
+
+  * link:http://localhost:8080/openapi.json
+  * link:http://localhost:8080/openapi.yaml
+
+Create the https://github.com/swagger-api/swagger-ui[Swagger console (UI)]:
+
+[source,bash]
+----
+docker run -itd --name console --rm -e URL="http://localhost:8080/openapi.json" -p 8888:8080 swaggerapi/swagger-ui
+----
+
+and navigate to http://localhost:8888 to open the swagger console

--- a/resteasy-examples/pom.xml
+++ b/resteasy-examples/pom.xml
@@ -6,13 +6,14 @@
 
   <groupId>io.vertx</groupId>
   <artifactId>resteasy-examples</artifactId>
-  <version>3.8.4</version>
+  <version>3.9.5</version>
   <name>resteasy-example</name>
 
   <properties>
     <!-- the main verticle class name -->
     <main.class>io.vertx.examples.spring.SpringExampleRunner</main.class>
     <resteasy.version>3.1.0.Final</resteasy.version>
+    <junit.version>4.13.1</junit.version>
   </properties>
 
   <dependencies>
@@ -32,6 +33,26 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-vertx</artifactId>
       <version>${resteasy.version}</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Swagger Code -->

--- a/resteasy-examples/pom.xml
+++ b/resteasy-examples/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.vertx</groupId>
   <artifactId>resteasy-examples</artifactId>
-  <version>4.0.0</version>
+  <version>3.8.4</version>
   <name>resteasy-example</name>
 
   <properties>
@@ -23,9 +23,38 @@
     </dependency>
 
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-vertx</artifactId>
       <version>${resteasy.version}</version>
+    </dependency>
+
+    <!-- Swagger Code -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-jaxrs2</artifactId>
+      <version>2.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+      <version>2.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <!-- Swagger needs it to create the Yaml open Api Json -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.12.1</version>
     </dependency>
 
   </dependencies>

--- a/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/ApplicationRs.java
+++ b/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/ApplicationRs.java
@@ -1,0 +1,21 @@
+package io.vertx.examples.resteasy.asyncresponse;
+
+
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The Application of the JAX-RS interface
+ *
+ */
+public class ApplicationRs extends Application {
+
+  private Set<Object> singletons = new HashSet<>();
+  @Override
+  public Set<Object> getSingletons() {
+    return singletons;
+  }
+
+
+}

--- a/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/Server.java
+++ b/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/Server.java
@@ -1,6 +1,9 @@
 package io.vertx.examples.resteasy.asyncresponse;
 
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.vertx.core.AbstractVerticle;
+import org.jboss.resteasy.plugins.interceptors.CorsFilter;
+import org.jboss.resteasy.plugins.server.vertx.VertxRegistry;
 import org.jboss.resteasy.plugins.server.vertx.VertxRequestHandler;
 import org.jboss.resteasy.plugins.server.vertx.VertxResteasyDeployment;
 
@@ -12,16 +15,36 @@ public class Server extends AbstractVerticle {
   @Override
   public void start() throws Exception {
 
+    /**
+     * Cors
+     * https://docs.jboss.org/resteasy/docs/4.5.8.Final/userguide/html_single/index.html#d4e2124
+     */
+    CorsFilter filter = new CorsFilter();
+    filter.getAllowedOrigins().add("*");
+    filter.setAllowedMethods("OPTIONS, GET, POST, DELETE, PUT, PATCH");
+    filter.setAllowedHeaders("Content-Type, Authorization");
+    filter.setCorsMaxAge(86400);//Max in FF 86400=24h https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+
+    /**
+     * https://docs.jboss.org/resteasy/docs/1.1.GA/userguide/html/Installation_Configuration.html#javax.ws.rs.core.Application
+     */
+    ApplicationRs application = new ApplicationRs();
+    application.getSingletons().add(filter);
+
     // Build the Jax-RS controller deployment
     VertxResteasyDeployment deployment = new VertxResteasyDeployment();
+    deployment.setApplication(application);
     deployment.start();
-    deployment.getRegistry().addPerInstanceResource(Controller.class);
+    VertxRegistry registry = deployment.getRegistry();
+    registry.addPerInstanceResource(Controller.class);
+    registry.addPerInstanceResource(OpenApiResource.class);
+
 
     // Start the front end server using the Jax-RS controller
     vertx.createHttpServer()
-        .requestHandler(new VertxRequestHandler(vertx, deployment))
-        .listen(8080, ar -> {
-          System.out.println("Server started on port "+ ar.result().actualPort());
-        });
+      .requestHandler(new VertxRequestHandler(vertx, deployment))
+      .listen(8080, ar -> {
+        System.out.println("Server started on port "+ ar.result().actualPort());
+      });
   }
 }

--- a/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/Server.java
+++ b/resteasy-examples/src/main/java/io/vertx/examples/resteasy/asyncresponse/Server.java
@@ -44,7 +44,11 @@ public class Server extends AbstractVerticle {
     vertx.createHttpServer()
       .requestHandler(new VertxRequestHandler(vertx, deployment))
       .listen(8080, ar -> {
-        System.out.println("Server started on port "+ ar.result().actualPort());
+        if (ar.succeeded()) {
+          System.out.println("Server started on port " + ar.result().actualPort());
+        } else {
+          ar.cause().printStackTrace();
+        }
       });
   }
 }

--- a/resteasy-examples/src/main/test/io/vertx/examples/resteasy/RestEasyTest.java
+++ b/resteasy-examples/src/main/test/io/vertx/examples/resteasy/RestEasyTest.java
@@ -1,0 +1,81 @@
+package io.vertx.examples.resteasy;
+
+import io.swagger.v3.core.util.Json;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.examples.resteasy.asyncresponse.Main;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class RestEasyTest {
+
+  private static WebClient webClient;
+  private static Vertx vertx;
+
+  @BeforeClass
+  public static void setUp() {
+
+
+    vertx = Vertx.vertx();
+    vertx.deployVerticle(new Main());
+    webClient = WebClient.create(vertx, new WebClientOptions()
+      .setDefaultPort(8080));
+
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    vertx.close();
+  }
+
+  @Test
+  public void base(TestContext context) {
+    Async async = context.async();
+    Promise<HttpResponse<JsonObject>> promise = Promise.promise();
+    webClient.get("/products")
+      .send(ar -> {
+        if (ar.succeeded()) {
+          JsonArray jsonArray = ar.result().bodyAsJsonArray();
+          System.out.println(Json.pretty(jsonArray));
+          context.assertEquals(3, jsonArray.size());
+          async.complete();
+        } else {
+          context.fail(ar.cause());
+          async.complete();
+        }
+      });
+    async.awaitSuccess(5000);
+  }
+
+  @Test
+  public void openApi(TestContext context) {
+    Async async = context.async();
+    Promise<HttpResponse<JsonObject>> promise = Promise.promise();
+    webClient.get("/openapi.json")
+      .send(ar -> {
+        if (ar.succeeded()) {
+          JsonObject jsonArray = ar.result().bodyAsJsonObject();
+          context.assertEquals(2, jsonArray.size());
+          context.assertEquals("3.0.1",jsonArray.getString("openapi"));
+          async.complete();
+        } else {
+          context.fail(ar.cause());
+          async.complete();
+        }
+      });
+    async.awaitSuccess(5000);
+  }
+
+
+}

--- a/web-examples/src/main/java/io/vertx/example/web/auth/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/auth/Server.java
@@ -33,7 +33,9 @@ public class Server extends AbstractVerticle {
     router.route("/private/*").handler(RedirectAuthHandler.create(authn, "/loginpage.html"));
 
     // Serve the static private pages from directory 'private'
-    router.route("/private/*").handler(StaticHandler.create().setCachingEnabled(false).setWebRoot("private"));
+    router.route("/private/*").handler(
+      StaticHandler.create().setCachingEnabled(false).setWebRoot("private")
+    );
 
     // Handles the actual login
     router.route("/loginhandler").handler(FormLoginHandler.create(authn));

--- a/web-examples/src/main/java/io/vertx/example/web/oauth2/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/oauth2/Server.java
@@ -27,11 +27,12 @@ public class Server extends AbstractVerticle {
   private static final String CLIENT_ID = "57cdaa1952a3f4ee3df8";
   private static final String CLIENT_SECRET = "3155eafd33fc947e0fe9f44127055ce1fe876704";
 
-  // In order to use a template we first need to create an engine
-  private final HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create(vertx);
-
   @Override
   public void start() throws Exception {
+
+    // In order to use a template we first need to create an engine
+    final HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create(vertx);
+
     // To simplify the development of the web components we use a Router to route all HTTP requests
     // to organize our code in a reusable way.
     final Router router = Router.router(vertx);

--- a/web-examples/src/main/java/io/vertx/example/web/react/.gitignore
+++ b/web-examples/src/main/java/io/vertx/example/web/react/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/web-examples/src/main/java/io/vertx/example/web/react/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/react/Server.java
@@ -33,7 +33,7 @@ public class Server extends AbstractVerticle {
     router.mountSubRouter("/eventbus", ebHandler.bridge(opts));
 
     // Create a router endpoint for the static content.
-    router.route().handler(StaticHandler.create());
+    router.route().handler(StaticHandler.create().setCachingEnabled(false));
 
     // Start the web server and tell it to use the router to handle requests.
     vertx.createHttpServer().requestHandler(router).listen(8080);

--- a/web-examples/src/main/java/io/vertx/example/web/staticsite/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/staticsite/Server.java
@@ -47,7 +47,7 @@ public class Server extends AbstractVerticle {
     Router router = Router.router(vertx);
 
     // Serve the static pages
-    router.route().handler(StaticHandler.create());
+    router.route().handler(StaticHandler.create().setCachingEnabled(false));
 
     vertx.createHttpServer().requestHandler(router).listen(8080);
 


### PR DESCRIPTION
Motivation:

I have added Swagger-Core in the example. 
The rest easy 4.0.0 example was not working already. I got an issue over unknown function.
I have downgraded it to 3.8. I know this is a 4.0 branch.

Conformance:

No problem to conform and to sign whatever is needed.

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
