### PR TITLE
make web api example easier to understand by making it move verbouse

### DIFF
--- a/web-api-service-example/pom.xml
+++ b/web-api-service-example/pom.xml
@@ -60,6 +60,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/web-api-service-example/src/main/java/io/vertx/examples/webapiservice/WebApiServiceExampleMainVerticle.java
+++ b/web-api-service-example/src/main/java/io/vertx/examples/webapiservice/WebApiServiceExampleMainVerticle.java
@@ -13,6 +13,8 @@ import io.vertx.examples.webapiservice.services.TransactionsManagerService;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import io.vertx.serviceproxy.ServiceBinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WebApiServiceExampleMainVerticle extends AbstractVerticle {
 
@@ -20,6 +22,7 @@ public class WebApiServiceExampleMainVerticle extends AbstractVerticle {
   ServiceBinder serviceBinder;
 
   MessageConsumer<JsonObject> consumer;
+  Logger LOG = LoggerFactory.getLogger(this.getClass());
 
   /**
    * Start transaction service
@@ -49,6 +52,9 @@ public class WebApiServiceExampleMainVerticle extends AbstractVerticle {
 
         // Generate the router
         Router router = routerBuilder.createRouter();
+        router.errorHandler(400, ctx -> {
+          LOG.debug("Bad Request", ctx.failure());
+        });
         server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost")).requestHandler(router);
         return server.listen().mapEmpty();
       });

--- a/web-api-service-example/src/main/resources/logback.xml
+++ b/web-api-service-example/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

I am trying to understand vertx openapi module by using an example in this repository. I found it to be too silent to quickly understand how it works and why I was getting Bad Requests errors.

I am opening this PR to have a chat if it's worth to make the examples more verbose to make sure the entry barrier is lowered and the examples are more accessible to new comers as me.

I really love the approach taken in vertx making the OpenAPI specification a configuration for the endpoints and validation layer. I think this is a gap which not many frameworks are filling these days. Keep up the good work! 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
