### PR TITLE
fix kafka.version from 2.4.0 to 2.6.0

### DIFF
--- a/kafka-examples/pom.xml
+++ b/kafka-examples/pom.xml
@@ -9,7 +9,7 @@
   <version>4.1.0</version>
 
   <properties>
-    <kafka.version>2.4.0</kafka.version>
+    <kafka.version>2.6.0</kafka.version>
     <debezium.version>0.8.3.Final</debezium.version>
   </properties>
 


### PR DESCRIPTION
vertx-kafka-client:4.1.0 depends on kafka_2.12:2.6.0, fix kafka.version from 2.4.0 to 2.6.0 in kafka-examples pom.xml
