### PR TITLE
chore!: removing the deprecated api in favor of latest

### DIFF
--- a/web-examples/src/main/java/io/vertx/example/web/realtime/Server.java
+++ b/web-examples/src/main/java/io/vertx/example/web/realtime/Server.java
@@ -43,7 +43,7 @@ public class Server extends AbstractVerticle {
       event.complete(true);
 
     });
-    router.mountSubRouter("/eventbus", subRouter);
+    router.route("/eventbus/*").subRouter(subRouter);
 
 
     // Serve the static resources


### PR DESCRIPTION
router.mountSubRouter("/eventbus", subRouter);
To 
router.route("/eventbus/*").subRouter(subRouter);

Motivation: To upgrade the code version to 4.


