### PR TITLE
Fix health example to use .addService instead of .bind

### DIFF
--- a/grpc-examples/src/main/java/io/vertx/example/grpc/health/Server.java
+++ b/grpc-examples/src/main/java/io/vertx/example/grpc/health/Server.java
@@ -44,7 +44,7 @@ public class Server extends VerticleBase {
     HealthService healthService = HealthService.create(vertx);
 
     // Bind the health service
-    healthService.bind(rpcServer);
+    rpcServer.addService(healthService);
 
     // By default, the health service always returns SERVING status for all services if they were registered through addService.
     // but you can register a specific health check for a specific service.


### PR DESCRIPTION
Motivation:

Fix health example to use .addService instead of .bind

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
