### PR TITLE
Add gRPC EventBus Bridge examples

### DIFF
--- a/grpc-eventbus-bridge-examples/README.adoc
+++ b/grpc-eventbus-bridge-examples/README.adoc
@@ -1,0 +1,50 @@
+= Vert.x gRPC EventBus Bridge examples
+
+Here you will find examples demonstrating the Vert.x gRPC EventBus Bridge in action.
+
+The gRPC EventBus Bridge allows any gRPC client to interact with a remote Vert.x instance via its EventBus.
+
+== Dependencies required
+
+To use Vert.x gRPC EventBus Bridge in your own Maven or Gradle project add the following dependency
+
+----
+Group ID: io.vertx
+Artifact ID: vertx-grpc-eventbus-bridge
+----
+
+== Send
+
+This example demonstrates sending a fire-and-forget message from a gRPC client to the Vert.x EventBus.
+
+The server starts the bridge and registers an EventBus consumer on the `hello` address.
+The client sends a message via gRPC which is delivered to the consumer.
+
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Server.java[Bridge server with EventBus consumer]
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Client.java[gRPC client sending a message]
+
+Run the server first, then the client.
+
+== Request-Response
+
+This example demonstrates the request-reply pattern through the gRPC bridge.
+
+The server starts the bridge and registers an EventBus consumer on the `echo` address that replies to messages.
+The client sends a request via gRPC and receives a response.
+
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Server.java[Bridge server with replying consumer]
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Client.java[gRPC client with request-response]
+
+Run the server first, then the client.
+
+== Publish-Subscribe
+
+This example demonstrates subscribing to EventBus messages via the gRPC bridge.
+
+The server starts the bridge and periodically publishes messages on the `news` address.
+The client subscribes via gRPC and receives a stream of messages.
+
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Server.java[Bridge server publishing messages]
+- link:src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Client.java[gRPC client subscribing to messages]
+
+Run the server first, then the client.

--- a/grpc-eventbus-bridge-examples/pom.xml
+++ b/grpc-eventbus-bridge-examples/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-examples</artifactId>
+    <version>5.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>grpc-eventbus-bridge-examples</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-launcher-application</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-eventbus-bridge-grpc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-grpc-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-grpc-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Client.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Client.java
@@ -1,0 +1,43 @@
+package io.vertx.example.grpc.eventbus.bridge.pubsub;
+
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.core.json.Json;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.event.v1alpha.EventBusBridgeGrpcClient;
+import io.vertx.grpc.event.v1alpha.JsonValueFormat;
+import io.vertx.grpc.event.v1alpha.SubscribeOp;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Client extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Client.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    GrpcClient client = GrpcClient.client(vertx);
+    SocketAddress serverAddress = SocketAddress.inetSocketAddress(8080, "localhost");
+    EventBusBridgeGrpcClient bridgeClient = EventBusBridgeGrpcClient.create(client, serverAddress);
+
+    // Subscribe to the "news" address
+    SubscribeOp request = SubscribeOp.newBuilder()
+      .setAddress("news")
+      .setMessageBodyFormatValue(JsonValueFormat.text_VALUE)
+      .build();
+
+    return bridgeClient.subscribe(request)
+      .onSuccess(stream -> {
+        stream.handler(message -> {
+          Object messageBody = Json.decodeValue(message.getBody().getText());
+          System.out.println("Received news: " + messageBody);
+        });
+        stream.exceptionHandler(err -> {
+          System.err.println("Stream error: " + err.getMessage());
+        });
+      })
+      .onFailure(err -> System.err.println("Failed to subscribe: " + err.getMessage()));
+  }
+}

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Server.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/pubsub/Server.java
@@ -1,0 +1,45 @@
+package io.vertx.example.grpc.eventbus.bridge.pubsub;
+
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.core.json.JsonObject;
+import io.vertx.eventbus.bridge.grpc.GrpcBridgeOptions;
+import io.vertx.eventbus.bridge.grpc.GrpcEventBusBridge;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Server extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Server.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    // Configure bridge options with outbound permission
+    GrpcBridgeOptions options = new GrpcBridgeOptions()
+      .addOutboundPermitted(new PermittedOptions().setAddress("news"));
+
+    // Create the bridge
+    GrpcEventBusBridge bridge = GrpcEventBusBridge.create(vertx, options);
+
+    // Create the gRPC server and add the bridge service
+    GrpcServer grpcServer = GrpcServer.server(vertx);
+    grpcServer.addService(bridge);
+
+    // Periodically publish news on the EventBus
+    vertx.setPeriodic(1000, id -> {
+      JsonObject news = new JsonObject()
+        .put("title", "News at " + System.currentTimeMillis());
+      vertx.eventBus().publish("news", news.encode());
+    });
+
+    // Start the HTTP server hosting the gRPC server
+    return vertx
+      .createHttpServer()
+      .requestHandler(grpcServer)
+      .listen(8080)
+      .onSuccess(v -> System.out.println("gRPC EventBus Bridge started on port 8080"));
+  }
+}

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Client.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Client.java
@@ -1,0 +1,48 @@
+package io.vertx.example.grpc.eventbus.bridge.requestresponse;
+
+import com.google.protobuf.Duration;
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.event.v1alpha.EventBusBridgeGrpcClient;
+import io.vertx.grpc.event.v1alpha.JsonValue;
+import io.vertx.grpc.event.v1alpha.JsonValueFormat;
+import io.vertx.grpc.event.v1alpha.RequestOp;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Client extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Client.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    GrpcClient client = GrpcClient.client(vertx);
+    SocketAddress serverAddress = SocketAddress.inetSocketAddress(8080, "localhost");
+    EventBusBridgeGrpcClient bridgeClient = EventBusBridgeGrpcClient.create(client, serverAddress);
+
+    // Create a message
+    JsonObject message = new JsonObject().put("value", "Hello from gRPC client");
+    JsonValue body = JsonValue.newBuilder().setText(message.encode()).build();
+
+    // Create the request with timeout
+    RequestOp request = RequestOp.newBuilder()
+      .setAddress("echo")
+      .setBody(body)
+      .setReplyBodyFormatValue(JsonValueFormat.text_VALUE)
+      .setTimeout(Duration.newBuilder().setSeconds(10).build())
+      .build();
+
+    // Send the request and receive the response
+    return bridgeClient.request(request)
+      .onSuccess(response -> {
+        Object responseBody = Json.decodeValue(response.getBody().getText());
+        System.out.println("Received response: " + responseBody);
+      })
+      .onFailure(err -> System.err.println("Request failed: " + err.getMessage()));
+  }
+}

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Server.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/requestresponse/Server.java
@@ -1,0 +1,43 @@
+package io.vertx.example.grpc.eventbus.bridge.requestresponse;
+
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.eventbus.bridge.grpc.GrpcBridgeOptions;
+import io.vertx.eventbus.bridge.grpc.GrpcEventBusBridge;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Server extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Server.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    // Register an EventBus consumer that echoes back the message
+    vertx.eventBus().consumer("echo", message -> {
+      System.out.println("Received request: " + message.body());
+      message.reply(message.body());
+    });
+
+    // Configure bridge options with inbound permission
+    GrpcBridgeOptions options = new GrpcBridgeOptions()
+      .addInboundPermitted(new PermittedOptions().setAddress("echo"));
+
+    // Create the bridge
+    GrpcEventBusBridge bridge = GrpcEventBusBridge.create(vertx, options);
+
+    // Create the gRPC server and add the bridge service
+    GrpcServer grpcServer = GrpcServer.server(vertx);
+    grpcServer.addService(bridge);
+
+    // Start the HTTP server hosting the gRPC server
+    return vertx
+      .createHttpServer()
+      .requestHandler(grpcServer)
+      .listen(8080)
+      .onSuccess(v -> System.out.println("gRPC EventBus Bridge started on port 8080"));
+  }
+}

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Client.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Client.java
@@ -1,0 +1,39 @@
+package io.vertx.example.grpc.eventbus.bridge.send;
+
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.event.v1alpha.EventBusBridgeGrpcClient;
+import io.vertx.grpc.event.v1alpha.JsonValue;
+import io.vertx.grpc.event.v1alpha.SendOp;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Client extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Client.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    GrpcClient client = GrpcClient.client(vertx);
+    SocketAddress serverAddress = SocketAddress.inetSocketAddress(8080, "localhost");
+    EventBusBridgeGrpcClient bridgeClient = EventBusBridgeGrpcClient.create(client, serverAddress);
+
+    // Create a message
+    JsonObject message = new JsonObject().put("value", "Hello from gRPC client");
+    JsonValue body = JsonValue.newBuilder().setText(message.encode()).build();
+
+    // Send the message to the "hello" address
+    SendOp request = SendOp.newBuilder()
+      .setAddress("hello")
+      .setBody(body)
+      .build();
+
+    return bridgeClient.send(request)
+      .onSuccess(v -> System.out.println("Message sent successfully"))
+      .onFailure(err -> System.err.println("Failed to send message: " + err.getMessage()));
+  }
+}

--- a/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Server.java
+++ b/grpc-eventbus-bridge-examples/src/main/java/io/vertx/example/grpc/eventbus/bridge/send/Server.java
@@ -1,0 +1,42 @@
+package io.vertx.example.grpc.eventbus.bridge.send;
+
+import io.vertx.core.Future;
+import io.vertx.core.VerticleBase;
+import io.vertx.eventbus.bridge.grpc.GrpcBridgeOptions;
+import io.vertx.eventbus.bridge.grpc.GrpcEventBusBridge;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.launcher.application.VertxApplication;
+
+public class Server extends VerticleBase {
+
+  public static void main(String[] args) {
+    VertxApplication.main(new String[]{Server.class.getName()});
+  }
+
+  @Override
+  public Future<?> start() {
+    // Register an EventBus consumer
+    vertx.eventBus().consumer("hello", message -> {
+      System.out.println("Received message: " + message.body());
+    });
+
+    // Configure bridge options with inbound permission
+    GrpcBridgeOptions options = new GrpcBridgeOptions()
+      .addInboundPermitted(new PermittedOptions().setAddress("hello"));
+
+    // Create the bridge
+    GrpcEventBusBridge bridge = GrpcEventBusBridge.create(vertx, options);
+
+    // Create the gRPC server and add the bridge service
+    GrpcServer grpcServer = GrpcServer.server(vertx);
+    grpcServer.addService(bridge);
+
+    // Start the HTTP server hosting the gRPC server
+    return vertx
+      .createHttpServer()
+      .requestHandler(grpcServer)
+      .listen(8080)
+      .onSuccess(v -> System.out.println("gRPC EventBus Bridge started on port 8080"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <module>service-resolver-examples</module>
     <module>mqtt-examples</module>
     <module>grpc-examples</module>
+    <module>grpc-eventbus-bridge-examples</module>
     <module>kafka-examples</module>
     <module>kotlin-coroutines-examples</module>
     <module>junit5-examples</module>


### PR DESCRIPTION
Motivation:

Showcase the usage of Vert.x gRPC EventBus Bridge.

Changes:

- Added examples for:
  - Fire-and-forget messaging (`send`).
  - Request-response pattern (`requestresponse`).
  - Publish-subscribe messaging (`pubsub`).